### PR TITLE
fix linting issues

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -344,7 +344,7 @@ func DecompressStream(archive io.Reader) (io.ReadCloser, error) {
 			},
 		}, nil
 	default:
-		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
+		return nil, fmt.Errorf("unsupported compression format: %s", (&compression).Extension())
 	}
 }
 
@@ -364,9 +364,9 @@ func CompressStream(dest io.Writer, compression Compression) (io.WriteCloser, er
 	case Bzip2, Xz:
 		// archive/bzip2 does not support writing, and there is no xz support at all
 		// However, this is not a problem as docker only currently generates gzipped tars
-		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
+		return nil, fmt.Errorf("unsupported compression format: %s", (&compression).Extension())
 	default:
-		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
+		return nil, fmt.Errorf("unsupported compression format: %s", (&compression).Extension())
 	}
 }
 
@@ -1309,7 +1309,7 @@ func UntarUncompressed(tarArchive io.Reader, dest string, options *TarOptions) e
 // Handler for teasing out the automatic decompression
 func untarHandler(tarArchive io.Reader, dest string, options *TarOptions, decompress bool) error {
 	if tarArchive == nil {
-		return fmt.Errorf("Empty archive")
+		return errors.New("empty archive")
 	}
 	dest = filepath.Clean(dest)
 	if options == nil {
@@ -1393,7 +1393,7 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 	}
 
 	if srcSt.IsDir() {
-		return fmt.Errorf("Can't copy a directory")
+		return errors.New("can't copy a directory")
 	}
 
 	// Clean up the trailing slash. This must be done in an operating

--- a/archive.go
+++ b/archive.go
@@ -768,7 +768,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 	case tar.TypeDir:
 		// Create directory unless it exists as a directory already.
 		// In that case we just want to merge the two
-		if fi, err := os.Lstat(path); !(err == nil && fi.IsDir()) {
+		if fi, err := os.Lstat(path); err != nil || !fi.IsDir() {
 			if err := os.Mkdir(path, hdrInfo.Mode()); err != nil {
 				return err
 			}
@@ -1217,7 +1217,7 @@ loop:
 				continue
 			}
 
-			if !(fi.IsDir() && hdr.Typeflag == tar.TypeDir) {
+			if !fi.IsDir() || hdr.Typeflag != tar.TypeDir {
 				if err := os.RemoveAll(path); err != nil {
 					return err
 				}

--- a/archive.go
+++ b/archive.go
@@ -1031,7 +1031,8 @@ func (t *Tarballer) Do() {
 		)
 
 		walkRoot := getWalkRoot(t.srcPath, include)
-		filepath.WalkDir(walkRoot, func(filePath string, f os.DirEntry, err error) error {
+		// TODO(thaJeztah): should this error be handled?
+		_ = filepath.WalkDir(walkRoot, func(filePath string, f os.DirEntry, err error) error {
 			if err != nil {
 				log.G(context.TODO()).Errorf("Tar: Can't stat file %s to tar: %s", t.srcPath, err)
 				return nil

--- a/archive_linux_test.go
+++ b/archive_linux_test.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"archive/tar"
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -119,7 +120,7 @@ func TestOverlayTarUntar(t *testing.T) {
 	rdr := tar.NewReader(bytes.NewReader(archive))
 	for {
 		h, err := rdr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		assert.NilError(t, err)

--- a/archive_test.go
+++ b/archive_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -766,7 +767,7 @@ func TestTarWithOptionsChownOptsAlwaysOverridesIdPair(t *testing.T) {
 			defer reader.Close()
 			for {
 				hdr, err := tr.Next()
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					// end of tar archive
 					break
 				}
@@ -838,7 +839,7 @@ func TestUntarUstarGnuConflict(t *testing.T) {
 	// Iterate through the files in the archive.
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			// end of tar archive
 			break
 		}

--- a/archive_test.go
+++ b/archive_test.go
@@ -650,9 +650,9 @@ func tarUntar(t *testing.T, origin string, options *TarOptions) ([]Change, error
 	wrap := io.MultiReader(bytes.NewReader(buf), archive)
 
 	detectedCompression := DetectCompression(buf)
-	compression := options.Compression
-	if detectedCompression.Extension() != compression.Extension() {
-		return nil, fmt.Errorf("Wrong compression detected. Actual compression: %s, found %s", compression.Extension(), detectedCompression.Extension())
+	expected := options.Compression
+	if detectedCompression.Extension() != expected.Extension() {
+		return nil, fmt.Errorf("wrong compression detected; expected: %s, got: %s", expected.Extension(), detectedCompression.Extension())
 	}
 
 	tmp := t.TempDir()

--- a/archive_test.go
+++ b/archive_test.go
@@ -480,22 +480,20 @@ func TestCopyWithTarSrcFile(t *testing.T) {
 	dest := filepath.Join(folder, "dest")
 	srcFolder := filepath.Join(folder, "src")
 	src := filepath.Join(folder, filepath.Join("src", "src"))
-	err := os.MkdirAll(srcFolder, 0o740)
-	if err != nil {
+	if err := os.MkdirAll(srcFolder, 0o740); err != nil {
 		t.Fatal(err)
 	}
-	err = os.MkdirAll(dest, 0o740)
-	if err != nil {
+	if err := os.MkdirAll(dest, 0o740); err != nil {
 		t.Fatal(err)
 	}
-	os.WriteFile(src, []byte("content"), 0o777)
-	err = defaultCopyWithTar(src, dest)
-	if err != nil {
+	if err := os.WriteFile(src, []byte("content"), 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := defaultCopyWithTar(src, dest); err != nil {
 		t.Fatalf("archiver.CopyWithTar shouldn't throw an error, %s.", err)
 	}
-	_, err = os.Stat(dest)
 	// FIXME Check the content
-	if err != nil {
+	if _, err := os.Stat(dest); err != nil {
 		t.Fatalf("Destination file should be the same as the source.")
 	}
 }
@@ -505,22 +503,20 @@ func TestCopyWithTarSrcFolder(t *testing.T) {
 	folder := t.TempDir()
 	dest := filepath.Join(folder, "dest")
 	src := filepath.Join(folder, filepath.Join("src", "folder"))
-	err := os.MkdirAll(src, 0o740)
-	if err != nil {
+	if err := os.MkdirAll(src, 0o740); err != nil {
 		t.Fatal(err)
 	}
-	err = os.MkdirAll(dest, 0o740)
-	if err != nil {
+	if err := os.MkdirAll(dest, 0o740); err != nil {
 		t.Fatal(err)
 	}
-	os.WriteFile(filepath.Join(src, "file"), []byte("content"), 0o777)
-	err = defaultCopyWithTar(src, dest)
-	if err != nil {
+	if err := os.WriteFile(filepath.Join(src, "file"), []byte("content"), 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := defaultCopyWithTar(src, dest); err != nil {
 		t.Fatalf("archiver.CopyWithTar shouldn't throw an error, %s.", err)
 	}
-	_, err = os.Stat(dest)
 	// FIXME Check the content (the file inside)
-	if err != nil {
+	if _, err := os.Stat(dest); err != nil {
 		t.Fatalf("Destination folder should contain the source file but did not.")
 	}
 }
@@ -581,21 +577,19 @@ func TestCopyFileWithTarSrcFile(t *testing.T) {
 	dest := filepath.Join(folder, "dest")
 	srcFolder := filepath.Join(folder, "src")
 	src := filepath.Join(folder, filepath.Join("src", "src"))
-	err := os.MkdirAll(srcFolder, 0o740)
-	if err != nil {
+	if err := os.MkdirAll(srcFolder, 0o740); err != nil {
 		t.Fatal(err)
 	}
-	err = os.MkdirAll(dest, 0o740)
-	if err != nil {
+	if err := os.MkdirAll(dest, 0o740); err != nil {
 		t.Fatal(err)
 	}
-	os.WriteFile(src, []byte("content"), 0o777)
-	err = defaultCopyWithTar(src, dest+"/")
-	if err != nil {
+	if err := os.WriteFile(src, []byte("content"), 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := defaultCopyWithTar(src, dest+"/"); err != nil {
 		t.Fatalf("archiver.CopyFileWithTar shouldn't throw an error, %s.", err)
 	}
-	_, err = os.Stat(dest)
-	if err != nil {
+	if _, err := os.Stat(dest); err != nil {
 		t.Fatalf("Destination folder should contain the source file but did not.")
 	}
 }

--- a/archive_unix_test.go
+++ b/archive_unix_test.go
@@ -5,6 +5,7 @@ package archive
 import (
 	"archive/tar"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -259,7 +260,7 @@ func TestTarUntarWithXattr(t *testing.T) {
 	rdr := tar.NewReader(tarball)
 	for {
 		h, err := rdr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		assert.NilError(t, err)

--- a/archive_windows.go
+++ b/archive_windows.go
@@ -41,11 +41,6 @@ func chmodTarEntry(perm os.FileMode) os.FileMode {
 	return perm | 0o111
 }
 
-func setHeaderForSpecialDevice(hdr *tar.Header, name string, stat interface{}) (err error) {
-	// do nothing. no notion of Rdev, Nlink in stat on Windows
-	return
-}
-
 func getInodeFromStat(stat interface{}) (uint64, error) {
 	// do nothing. no notion of Inode in stat on Windows
 	return 0, nil

--- a/archive_windows_test.go
+++ b/archive_windows_test.go
@@ -21,11 +21,12 @@ func TestCopyFileWithInvalidDest(t *testing.T) {
 	dest := "c:dest"
 	srcFolder := filepath.Join(folder, "src")
 	src := filepath.Join(folder, "src", "src")
-	err = os.MkdirAll(srcFolder, 0o740)
-	if err != nil {
+	if err := os.MkdirAll(srcFolder, 0o740); err != nil {
 		t.Fatal(err)
 	}
-	os.WriteFile(src, []byte("content"), 0o777)
+	if err := os.WriteFile(src, []byte("content"), 0o777); err != nil {
+		t.Fatal(err)
+	}
 	err = defaultCopyWithTar(src, dest)
 	if err == nil {
 		t.Fatalf("archiver.CopyWithTar should throw an error on invalid dest.")

--- a/changes.go
+++ b/changes.go
@@ -75,7 +75,7 @@ func sameFsTime(a, b time.Time) bool {
 // Changes walks the path rw and determines changes for the files in the path,
 // with respect to the parent layers
 func Changes(layers []string, rw string) ([]Change, error) {
-	return changes(layers, rw, aufsDeletedFile, aufsMetadataSkip)
+	return collectChanges(layers, rw, aufsDeletedFile, aufsMetadataSkip)
 }
 
 func aufsMetadataSkip(path string) (skip bool, err error) {
@@ -103,7 +103,7 @@ type (
 	deleteChange func(string, string, os.FileInfo) (string, error)
 )
 
-func changes(layers []string, rw string, dc deleteChange, sc skipChange) ([]Change, error) {
+func collectChanges(layers []string, rw string, dc deleteChange, sc skipChange) ([]Change, error) {
 	var (
 		changes     []Change
 		changedDirs = make(map[string]struct{})

--- a/changes_linux.go
+++ b/changes_linux.go
@@ -132,14 +132,7 @@ func (w *walker) walk(path string, i1, i2 os.FileInfo) (err error) {
 	ix1 := 0
 	ix2 := 0
 
-	for {
-		if ix1 >= len(names1) {
-			break
-		}
-		if ix2 >= len(names2) {
-			break
-		}
-
+	for ix1 < len(names1) && ix2 < len(names2) {
 		ni1 := names1[ix1]
 		ni2 := names2[ix2]
 

--- a/changes_posix_test.go
+++ b/changes_posix_test.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"archive/tar"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -112,7 +113,7 @@ func walkHeaders(r io.Reader) ([]tar.Header, error) {
 	for {
 		hdr, err := t.Next()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return headers, err

--- a/changes_test.go
+++ b/changes_test.go
@@ -95,13 +95,14 @@ func provisionSampleDir(t *testing.T, root string, files []FileData) {
 	now := time.Now()
 	for _, info := range files {
 		p := path.Join(root, info.path)
-		if info.filetype == Dir {
+		switch info.filetype {
+		case Dir:
 			err := os.MkdirAll(p, info.permissions)
 			assert.NilError(t, err)
-		} else if info.filetype == Regular {
+		case Regular:
 			err := os.WriteFile(p, []byte(info.contents), info.permissions)
 			assert.NilError(t, err)
-		} else if info.filetype == Symlink {
+		case Symlink:
 			err := os.Symlink(info.contents, p)
 			assert.NilError(t, err)
 		}

--- a/changes_test.go
+++ b/changes_test.go
@@ -150,7 +150,7 @@ func TestChangesWithChanges(t *testing.T) {
 	assert.NilError(t, err)
 	defer os.RemoveAll(layer)
 	createSampleDir(t, layer)
-	os.MkdirAll(path.Join(layer, "dir1/subfolder"), 0o740)
+	assert.NilError(t, os.MkdirAll(path.Join(layer, "dir1/subfolder"), 0o740))
 
 	// Mock the RW layer
 	rwLayer, err := os.MkdirTemp("", "docker-changes-test")
@@ -159,16 +159,16 @@ func TestChangesWithChanges(t *testing.T) {
 
 	// Create a folder in RW layer
 	dir1 := path.Join(rwLayer, "dir1")
-	os.MkdirAll(dir1, 0o740)
+	assert.NilError(t, os.MkdirAll(dir1, 0o740))
 	deletedFile := path.Join(dir1, ".wh.file1-2")
-	os.WriteFile(deletedFile, []byte{}, 0o600)
+	assert.NilError(t, os.WriteFile(deletedFile, []byte{}, 0o600))
 	modifiedFile := path.Join(dir1, "file1-1")
-	os.WriteFile(modifiedFile, []byte{0x00}, 0o1444)
+	assert.NilError(t, os.WriteFile(modifiedFile, []byte{0x00}, 0o1444))
 	// Let's add a subfolder for a newFile
 	subfolder := path.Join(dir1, "subfolder")
-	os.MkdirAll(subfolder, 0o740)
+	assert.NilError(t, os.MkdirAll(subfolder, 0o740))
 	newFile := path.Join(subfolder, "newFile")
-	os.WriteFile(newFile, []byte{}, 0o740)
+	assert.NilError(t, os.WriteFile(newFile, []byte{}, 0o740))
 
 	changes, err := Changes([]string{layer}, rwLayer)
 	assert.NilError(t, err)
@@ -194,10 +194,10 @@ func TestChangesWithChangesGH13590(t *testing.T) {
 	defer os.RemoveAll(baseLayer)
 
 	dir3 := path.Join(baseLayer, "dir1/dir2/dir3")
-	os.MkdirAll(dir3, 0o740)
+	assert.NilError(t, os.MkdirAll(dir3, 0o740))
 
 	file := path.Join(dir3, "file.txt")
-	os.WriteFile(file, []byte("hello"), 0o666)
+	assert.NilError(t, os.WriteFile(file, []byte("hello"), 0o666))
 
 	layer, err := os.MkdirTemp("", "docker-changes-test2.")
 	assert.NilError(t, err)
@@ -208,9 +208,9 @@ func TestChangesWithChangesGH13590(t *testing.T) {
 		t.Fatalf("Cmd failed: %q", err)
 	}
 
-	os.Remove(path.Join(layer, "dir1/dir2/dir3/file.txt"))
+	assert.NilError(t, os.Remove(path.Join(layer, "dir1/dir2/dir3/file.txt")))
 	file = path.Join(layer, "dir1/dir2/dir3/file1.txt")
-	os.WriteFile(file, []byte("bye"), 0o666)
+	assert.NilError(t, os.WriteFile(file, []byte("bye"), 0o666))
 
 	changes, err := Changes([]string{baseLayer}, layer)
 	assert.NilError(t, err)
@@ -231,7 +231,7 @@ func TestChangesWithChangesGH13590(t *testing.T) {
 	}
 
 	file = path.Join(layer, "dir1/dir2/dir3/file.txt")
-	os.WriteFile(file, []byte("bye"), 0o666)
+	assert.NilError(t, os.WriteFile(file, []byte("bye"), 0o666))
 
 	changes, err = Changes([]string{baseLayer}, layer)
 	assert.NilError(t, err)
@@ -262,8 +262,8 @@ func TestChangesDirsEmpty(t *testing.T) {
 	if len(changes) != 0 {
 		t.Fatalf("Reported changes for identical dirs: %v", changes)
 	}
-	os.RemoveAll(src)
-	os.RemoveAll(dst)
+	assert.NilError(t, os.RemoveAll(src))
+	assert.NilError(t, os.RemoveAll(dst))
 }
 
 func mutateSampleDir(t *testing.T, root string) {
@@ -340,8 +340,10 @@ func TestChangesDirsMutated(t *testing.T) {
 	dst := src + "-copy"
 	err = copyDir(src, dst)
 	assert.NilError(t, err)
-	defer os.RemoveAll(src)
-	defer os.RemoveAll(dst)
+	defer func() {
+		_ = os.RemoveAll(dst)
+		_ = os.RemoveAll(src)
+	}()
 
 	mutateSampleDir(t, dst)
 

--- a/changes_test.go
+++ b/changes_test.go
@@ -195,7 +195,7 @@ func TestChangesWithChangesGH13590(t *testing.T) {
 	defer os.RemoveAll(baseLayer)
 
 	dir3 := path.Join(baseLayer, "dir1/dir2/dir3")
-	os.MkdirAll(dir3, 0o7400)
+	os.MkdirAll(dir3, 0o740)
 
 	file := path.Join(dir3, "file.txt")
 	os.WriteFile(file, []byte("hello"), 0o666)

--- a/changes_test.go
+++ b/changes_test.go
@@ -113,20 +113,17 @@ func provisionSampleDir(t *testing.T, root string, files []FileData) {
 }
 
 func TestChangeString(t *testing.T) {
-	modifyChange := Change{"change", ChangeModify}
-	toString := modifyChange.String()
-	if toString != "C change" {
-		t.Fatalf("String() of a change with ChangeModify Kind should have been %s but was %s", "C change", toString)
+	actual := (&Change{Path: "change", Kind: ChangeModify}).String()
+	if actual != "C change" {
+		t.Fatalf("String() of a change with ChangeModify Kind should have been %s but was %s", "C change", actual)
 	}
-	addChange := Change{"change", ChangeAdd}
-	toString = addChange.String()
-	if toString != "A change" {
-		t.Fatalf("String() of a change with ChangeAdd Kind should have been %s but was %s", "A change", toString)
+	actual = (&Change{Path: "change", Kind: ChangeAdd}).String()
+	if actual != "A change" {
+		t.Fatalf("String() of a change with ChangeAdd Kind should have been %s but was %s", "A change", actual)
 	}
-	deleteChange := Change{"change", ChangeDelete}
-	toString = deleteChange.String()
-	if toString != "D change" {
-		t.Fatalf("String() of a change with ChangeDelete Kind should have been %s but was %s", "D change", toString)
+	actual = (&Change{Path: "change", Kind: ChangeDelete}).String()
+	if actual != "D change" {
+		t.Fatalf("String() of a change with ChangeDelete Kind should have been %s but was %s", "D change", actual)
 	}
 }
 
@@ -175,11 +172,11 @@ func TestChangesWithChanges(t *testing.T) {
 	assert.NilError(t, err)
 
 	expectedChanges := []Change{
-		{filepath.FromSlash("/dir1"), ChangeModify},
-		{filepath.FromSlash("/dir1/file1-1"), ChangeModify},
-		{filepath.FromSlash("/dir1/file1-2"), ChangeDelete},
-		{filepath.FromSlash("/dir1/subfolder"), ChangeModify},
-		{filepath.FromSlash("/dir1/subfolder/newFile"), ChangeAdd},
+		{Path: filepath.FromSlash("/dir1"), Kind: ChangeModify},
+		{Path: filepath.FromSlash("/dir1/file1-1"), Kind: ChangeModify},
+		{Path: filepath.FromSlash("/dir1/file1-2"), Kind: ChangeDelete},
+		{Path: filepath.FromSlash("/dir1/subfolder"), Kind: ChangeModify},
+		{Path: filepath.FromSlash("/dir1/subfolder/newFile"), Kind: ChangeAdd},
 	}
 	checkChanges(expectedChanges, changes, t)
 }
@@ -217,8 +214,8 @@ func TestChangesWithChangesGH13590(t *testing.T) {
 	assert.NilError(t, err)
 
 	expectedChanges := []Change{
-		{"/dir1/dir2/dir3", ChangeModify},
-		{"/dir1/dir2/dir3/file1.txt", ChangeAdd},
+		{Path: "/dir1/dir2/dir3", Kind: ChangeModify},
+		{Path: "/dir1/dir2/dir3/file1.txt", Kind: ChangeAdd},
 	}
 	checkChanges(expectedChanges, changes, t)
 
@@ -238,7 +235,7 @@ func TestChangesWithChangesGH13590(t *testing.T) {
 	assert.NilError(t, err)
 
 	expectedChanges = []Change{
-		{"/dir1/dir2/dir3/file.txt", ChangeModify},
+		{Path: "/dir1/dir2/dir3/file.txt", Kind: ChangeModify},
 	}
 	checkChanges(expectedChanges, changes, t)
 }
@@ -352,8 +349,8 @@ func TestChangesDirsMutated(t *testing.T) {
 	sort.Sort(changesByPath(changes))
 
 	expectedChanges := []Change{
-		{filepath.FromSlash("/dir1"), ChangeDelete},
-		{filepath.FromSlash("/dir2"), ChangeModify},
+		{Path: filepath.FromSlash("/dir1"), Kind: ChangeDelete},
+		{Path: filepath.FromSlash("/dir2"), Kind: ChangeModify},
 	}
 
 	// Note there is slight difference between the Linux and Windows
@@ -367,20 +364,20 @@ func TestChangesDirsMutated(t *testing.T) {
 	// this is in the middle of the list of changes rather than at the start or
 	// end. Potentially can be addressed later.
 	if runtime.GOOS == "windows" {
-		expectedChanges = append(expectedChanges, Change{filepath.FromSlash("/dir3"), ChangeModify})
+		expectedChanges = append(expectedChanges, Change{Path: filepath.FromSlash("/dir3"), Kind: ChangeModify})
 	}
 
 	expectedChanges = append(expectedChanges, []Change{
-		{filepath.FromSlash("/dirnew"), ChangeAdd},
-		{filepath.FromSlash("/file1"), ChangeDelete},
-		{filepath.FromSlash("/file2"), ChangeModify},
-		{filepath.FromSlash("/file3"), ChangeModify},
-		{filepath.FromSlash("/file4"), ChangeModify},
-		{filepath.FromSlash("/file5"), ChangeModify},
-		{filepath.FromSlash("/filenew"), ChangeAdd},
-		{filepath.FromSlash("/symlink1"), ChangeDelete},
-		{filepath.FromSlash("/symlink2"), ChangeModify},
-		{filepath.FromSlash("/symlinknew"), ChangeAdd},
+		{Path: filepath.FromSlash("/dirnew"), Kind: ChangeAdd},
+		{Path: filepath.FromSlash("/file1"), Kind: ChangeDelete},
+		{Path: filepath.FromSlash("/file2"), Kind: ChangeModify},
+		{Path: filepath.FromSlash("/file3"), Kind: ChangeModify},
+		{Path: filepath.FromSlash("/file4"), Kind: ChangeModify},
+		{Path: filepath.FromSlash("/file5"), Kind: ChangeModify},
+		{Path: filepath.FromSlash("/filenew"), Kind: ChangeAdd},
+		{Path: filepath.FromSlash("/symlink1"), Kind: ChangeDelete},
+		{Path: filepath.FromSlash("/symlink2"), Kind: ChangeModify},
+		{Path: filepath.FromSlash("/symlinknew"), Kind: ChangeAdd},
 	}...)
 
 	for i := 0; i < maxInt(len(changes), len(expectedChanges)); i++ {
@@ -479,10 +476,9 @@ func TestChangesSizeWithNoChanges(t *testing.T) {
 }
 
 func TestChangesSizeWithOnlyDeleteChanges(t *testing.T) {
-	changes := []Change{
+	size := ChangesSize("/tmp", []Change{
 		{Path: "deletedPath", Kind: ChangeDelete},
-	}
-	size := ChangesSize("/tmp", changes)
+	})
 	if size != 0 {
 		t.Fatalf("ChangesSizes with only delete changes should be 0, was %d", size)
 	}
@@ -499,11 +495,10 @@ func TestChangesSize(t *testing.T) {
 	err = os.WriteFile(modification, []byte{0x01, 0x01, 0x01}, 0o744)
 	assert.NilError(t, err)
 
-	changes := []Change{
+	size := ChangesSize(parentPath, []Change{
 		{Path: "addition", Kind: ChangeAdd},
 		{Path: "modification", Kind: ChangeModify},
-	}
-	size := ChangesSize(parentPath, changes)
+	})
 	if size != 6 {
 		t.Fatalf("Expected 6 bytes of changes, got %d", size)
 	}

--- a/changes_test.go
+++ b/changes_test.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path"
@@ -34,8 +35,9 @@ func copyDir(src, dst string) error {
 	// Use robocopy instead. Note this isn't available in microsoft/nanoserver.
 	// But it has gotchas. See https://weblogs.sqlteam.com/robv/archive/2010/02/17/61106.aspx
 	err := exec.Command("robocopy", filepath.FromSlash(src), filepath.FromSlash(dst), "/SL", "/COPYALL", "/MIR").Run()
-	if exiterr, ok := err.(*exec.ExitError); ok {
-		if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
+		if status, ok := exitError.Sys().(syscall.WaitStatus); ok {
 			if status.ExitStatus()&24 == 0 {
 				return nil
 			}

--- a/chrootarchive/archive.go
+++ b/chrootarchive/archive.go
@@ -1,7 +1,7 @@
 package chrootarchive
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -53,7 +53,7 @@ func UntarUncompressed(tarArchive io.Reader, dest string, options *archive.TarOp
 // Handler for teasing out the automatic decompression
 func untarHandler(tarArchive io.Reader, dest string, options *archive.TarOptions, decompress bool, root string) error {
 	if tarArchive == nil {
-		return fmt.Errorf("Empty archive")
+		return errors.New("empty archive")
 	}
 	if options == nil {
 		options = &archive.TarOptions{}

--- a/chrootarchive/archive_test.go
+++ b/chrootarchive/archive_test.go
@@ -137,7 +137,7 @@ func compareDirectories(src string, dest string) error {
 		return err
 	}
 	if len(changes) > 0 {
-		return fmt.Errorf("Unexpected differences after untar: %v", changes)
+		return fmt.Errorf("unexpected differences after untar: %v", changes)
 	}
 	return nil
 }

--- a/chrootarchive/archive_test.go
+++ b/chrootarchive/archive_test.go
@@ -125,7 +125,9 @@ func getHash(filename string) (uint32, error) {
 		return 0, err
 	}
 	hash := crc32.NewIEEE()
-	hash.Write(stream)
+	if _, err := hash.Write(stream); err != nil {
+		return 0, err
+	}
 	return hash.Sum32(), nil
 }
 
@@ -282,7 +284,9 @@ func TestChrootUntarPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(stream)
+	if _, err := buf.ReadFrom(stream); err != nil {
+		t.Fatal(err)
+	}
 	tarfile := filepath.Join(tmpdir, "src.tar")
 	if err := os.WriteFile(tarfile, buf.Bytes(), 0o644); err != nil {
 		t.Fatal(err)

--- a/chrootarchive/archive_test.go
+++ b/chrootarchive/archive_test.go
@@ -102,21 +102,21 @@ func TestChrootUntarEmptyArchive(t *testing.T) {
 	}
 }
 
-func prepareSourceDirectory(numberOfFiles int, targetPath string, makeSymLinks bool) (int, error) {
+func prepareSourceDirectory(targetPath string, makeSymLinks bool) error {
 	fileData := []byte("fooo")
+	numberOfFiles := 10
 	for n := 0; n < numberOfFiles; n++ {
 		fileName := fmt.Sprintf("file-%d", n)
 		if err := os.WriteFile(filepath.Join(targetPath, fileName), fileData, 0o700); err != nil {
-			return 0, err
+			return err
 		}
 		if makeSymLinks {
 			if err := os.Symlink(filepath.Join(targetPath, fileName), filepath.Join(targetPath, fileName+"-link")); err != nil {
-				return 0, err
+				return err
 			}
 		}
 	}
-	totalSize := numberOfFiles * len(fileData)
-	return totalSize, nil
+	return nil
 }
 
 func getHash(filename string) (uint32, error) {
@@ -165,7 +165,7 @@ func TestChrootTarUntarWithSymlink(t *testing.T) {
 	if err := os.Mkdir(src, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := prepareSourceDirectory(10, src, false); err != nil {
+	if err := prepareSourceDirectory(src, false); err != nil {
 		t.Fatal(err)
 	}
 	dest := filepath.Join(tmpdir, "dest")
@@ -185,7 +185,7 @@ func TestChrootCopyWithTar(t *testing.T) {
 	if err := os.Mkdir(src, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := prepareSourceDirectory(10, src, true); err != nil {
+	if err := prepareSourceDirectory(src, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -228,7 +228,7 @@ func TestChrootCopyFileWithTar(t *testing.T) {
 	if err := os.Mkdir(src, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := prepareSourceDirectory(10, src, true); err != nil {
+	if err := prepareSourceDirectory(src, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -269,7 +269,7 @@ func TestChrootUntarPath(t *testing.T) {
 	if err := os.Mkdir(src, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := prepareSourceDirectory(10, src, false); err != nil {
+	if err := prepareSourceDirectory(src, false); err != nil {
 		t.Fatal(err)
 	}
 	dest := filepath.Join(tmpdir, "dest")

--- a/chrootarchive/archive_unix_test.go
+++ b/chrootarchive/archive_unix_test.go
@@ -5,6 +5,7 @@ package chrootarchive
 import (
 	gotar "archive/tar"
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path"
@@ -152,7 +153,7 @@ func TestTarWithMaliciousSymlinks(t *testing.T) {
 func isDataInTar(t *testing.T, tr *gotar.Reader, compare []byte, maxBytes int64) bool {
 	for {
 		h, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		assert.NilError(t, err)

--- a/chrootarchive/archive_unix_test.go
+++ b/chrootarchive/archive_unix_test.go
@@ -69,7 +69,8 @@ func TestUntarWithMaliciousSymlinks(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, string(hostData), "I am a host file")
 
-	io.Copy(io.Discard, tee)
+	_, err = io.Copy(io.Discard, tee)
+	assert.NilError(t, err)
 
 	// Now test by chrooting to an attacker controlled path
 	// This should succeed as is and overwrite a "host" file

--- a/chrootarchive/diff_windows.go
+++ b/chrootarchive/diff_windows.go
@@ -26,7 +26,7 @@ func applyLayerHandler(dest string, layer io.Reader, options *archive.TarOptions
 	dest = addLongPathPrefix(filepath.Clean(dest))
 	s, err := archive.UnpackLayer(dest, layer, nil)
 	if err != nil {
-		return 0, fmt.Errorf("ApplyLayer %s failed UnpackLayer to %s: %s", layer, dest, err)
+		return 0, fmt.Errorf("ApplyLayer %s failed UnpackLayer to %s: %w", layer, dest, err)
 	}
 
 	return s, nil

--- a/copy.go
+++ b/copy.go
@@ -335,7 +335,7 @@ func RebaseArchiveEntries(srcContent io.Reader, oldBase, newBase string) io.Read
 
 		for {
 			hdr, err := srcTar.Next()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				// Signals end of archive.
 				rebasedTar.Close()
 				w.Close()

--- a/copy_unix_test.go
+++ b/copy_unix_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -355,7 +356,7 @@ func TestCopyCaseB(t *testing.T) {
 		t.Fatal("expected ErrDirNotExists error, but got nil instead")
 	}
 
-	if err != ErrDirNotExists {
+	if !errors.Is(err, ErrDirNotExists) {
 		t.Fatalf("expected ErrDirNotExists error, but got %T: %s", err, err)
 	}
 
@@ -364,7 +365,7 @@ func TestCopyCaseB(t *testing.T) {
 	if err = testCopyHelperFSym(t, symlinkPath, dstDir); err == nil {
 		t.Fatal("expected ErrDirNotExists error, but got nil instead")
 	}
-	if err != ErrDirNotExists {
+	if !errors.Is(err, ErrDirNotExists) {
 		t.Fatalf("expected ErrDirNotExists error, but got %T: %s", err, err)
 	}
 }
@@ -647,7 +648,7 @@ func TestCopyCaseF(t *testing.T) {
 		t.Fatal("expected ErrCannotCopyDir error, but got nil instead")
 	}
 
-	if err != ErrCannotCopyDir {
+	if !errors.Is(err, ErrCannotCopyDir) {
 		t.Fatalf("expected ErrCannotCopyDir error, but got %T: %s", err, err)
 	}
 
@@ -656,7 +657,7 @@ func TestCopyCaseF(t *testing.T) {
 		t.Fatal("expected ErrCannotCopyDir error, but got nil instead")
 	}
 
-	if err != ErrCannotCopyDir {
+	if !errors.Is(err, ErrCannotCopyDir) {
 		t.Fatalf("expected ErrCannotCopyDir error, but got %T: %s", err, err)
 	}
 }
@@ -871,7 +872,7 @@ func TestCopyCaseI(t *testing.T) {
 		t.Fatal("expected ErrCannotCopyDir error, but got nil instead")
 	}
 
-	if err != ErrCannotCopyDir {
+	if !errors.Is(err, ErrCannotCopyDir) {
 		t.Fatalf("expected ErrCannotCopyDir error, but got %T: %s", err, err)
 	}
 
@@ -880,7 +881,7 @@ func TestCopyCaseI(t *testing.T) {
 		t.Fatal("expected ErrCannotCopyDir error, but got nil instead")
 	}
 
-	if err != ErrCannotCopyDir {
+	if !errors.Is(err, ErrCannotCopyDir) {
 		t.Fatalf("expected ErrCannotCopyDir error, but got %T: %s", err, err)
 	}
 }

--- a/diff.go
+++ b/diff.go
@@ -166,7 +166,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				linkBasename := filepath.Base(hdr.Linkname)
 				srcHdr = aufsHardlinks[linkBasename]
 				if srcHdr == nil {
-					return 0, fmt.Errorf("Invalid aufs hardlink")
+					return 0, errors.New("invalid aufs hardlink")
 				}
 				tmpFile, err := os.Open(filepath.Join(aufsTempdir, linkBasename))
 				if err != nil {

--- a/diff.go
+++ b/diff.go
@@ -150,7 +150,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			// the layer is also a directory. Then we want to merge them (i.e.
 			// just apply the metadata from the layer).
 			if fi, err := os.Lstat(path); err == nil {
-				if !(fi.IsDir() && hdr.Typeflag == tar.TypeDir) {
+				if !fi.IsDir() || hdr.Typeflag != tar.TypeDir {
 					if err := os.RemoveAll(path); err != nil {
 						return 0, err
 					}

--- a/diff_test.go
+++ b/diff_test.go
@@ -223,11 +223,11 @@ func TestApplyLayerWhiteouts(t *testing.T) {
 
 	tcases := []tcase{
 		{
-			base,
-			base,
+			change:   base,
+			expected: base,
 		},
 		{
-			[]string{
+			change: []string{
 				".bay",
 				".wh.baz",
 				"foo/",
@@ -236,7 +236,7 @@ func TestApplyLayerWhiteouts(t *testing.T) {
 				"foo/cde/",
 				"foo/cde/efg",
 			},
-			[]string{
+			expected: []string{
 				".bay",
 				".baz",
 				"bar/",
@@ -250,7 +250,7 @@ func TestApplyLayerWhiteouts(t *testing.T) {
 			},
 		},
 		{
-			[]string{
+			change: []string{
 				".bay",
 				".wh..baz",
 				".wh.foobar",
@@ -259,7 +259,7 @@ func TestApplyLayerWhiteouts(t *testing.T) {
 				"foo/.wh.cde",
 				"bar/",
 			},
-			[]string{
+			expected: []string{
 				".bay",
 				"bar/",
 				"bar/bax",
@@ -270,12 +270,12 @@ func TestApplyLayerWhiteouts(t *testing.T) {
 			},
 		},
 		{
-			[]string{
+			change: []string{
 				".abc",
 				".wh..wh..opq",
 				"foobar",
 			},
-			[]string{
+			expected: []string{
 				".abc",
 				"foobar",
 			},

--- a/example_changes.go
+++ b/example_changes.go
@@ -73,7 +73,7 @@ func main() {
 	defer a.Close()
 
 	i, err := io.Copy(os.Stdout, a)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		log.Fatal(err)
 	}
 	fmt.Fprintf(os.Stderr, "wrote archive of %d bytes", i)

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -27,7 +27,7 @@ func FuzzUntar(f *testing.F) {
 			return
 		}
 		tmpDir := t.TempDir()
-		Untar(bytes.NewReader(tarBytes), tmpDir, options)
+		_ = Untar(bytes.NewReader(tarBytes), tmpDir, options)
 	})
 }
 

--- a/internal/mounttree/switchroot_linux.go
+++ b/internal/mounttree/switchroot_linux.go
@@ -26,7 +26,7 @@ func SwitchRoot(path string) error {
 	// setup oldRoot for pivot_root
 	pivotDir, err := os.MkdirTemp(path, ".pivot_root")
 	if err != nil {
-		return fmt.Errorf("Error setting up pivot dir: %v", err)
+		return fmt.Errorf("error setting up pivot dir: %w", err)
 	}
 
 	var mounted bool
@@ -45,7 +45,7 @@ func SwitchRoot(path string) error {
 		// pivotDir doesn't exist if pivot_root failed and chroot+chdir was successful
 		// because we already cleaned it up on failed pivot_root
 		if errCleanup != nil && !os.IsNotExist(errCleanup) {
-			errCleanup = fmt.Errorf("Error cleaning up after pivot: %v", errCleanup)
+			errCleanup = fmt.Errorf("error cleaning up after pivot: %w", errCleanup)
 			if err == nil {
 				err = errCleanup
 			}
@@ -55,7 +55,7 @@ func SwitchRoot(path string) error {
 	if err := unix.PivotRoot(path, pivotDir); err != nil {
 		// If pivot fails, fall back to the normal chroot after cleaning up temp dir
 		if err := os.Remove(pivotDir); err != nil {
-			return fmt.Errorf("Error cleaning up after failed pivot: %v", err)
+			return fmt.Errorf("error cleaning up after failed pivot: %w", err)
 		}
 		return realChroot(path)
 	}
@@ -66,17 +66,17 @@ func SwitchRoot(path string) error {
 	pivotDir = filepath.Join("/", filepath.Base(pivotDir))
 
 	if err := unix.Chdir("/"); err != nil {
-		return fmt.Errorf("Error changing to new root: %v", err)
+		return fmt.Errorf("error changing to new root: %w", err)
 	}
 
 	// Make the pivotDir (where the old root lives) private so it can be unmounted without propagating to the host
 	if err := unix.Mount("", pivotDir, "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
-		return fmt.Errorf("Error making old root private after pivot: %v", err)
+		return fmt.Errorf("error making old root private after pivot: %w", err)
 	}
 
 	// Now unmount the old root so it's no longer visible from the new root
 	if err := unix.Unmount(pivotDir, unix.MNT_DETACH); err != nil {
-		return fmt.Errorf("Error while unmounting old root after pivot: %v", err)
+		return fmt.Errorf("error while unmounting old root after pivot: %w", err)
 	}
 	mounted = false
 
@@ -85,10 +85,10 @@ func SwitchRoot(path string) error {
 
 func realChroot(path string) error {
 	if err := unix.Chroot(path); err != nil {
-		return fmt.Errorf("Error after fallback to chroot: %v", err)
+		return fmt.Errorf("error after fallback to chroot: %w", err)
 	}
 	if err := unix.Chdir("/"); err != nil {
-		return fmt.Errorf("Error changing to new root after chroot: %v", err)
+		return fmt.Errorf("error changing to new root after chroot: %w", err)
 	}
 	return nil
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -66,9 +66,9 @@ func testBreakout(untarFn string, tmpdir string, headers []*tar.Header) error {
 	go func() {
 		t := tar.NewWriter(writer)
 		for _, hdr := range headers {
-			t.WriteHeader(hdr)
+			_ = t.WriteHeader(hdr)
 		}
-		t.Close()
+		_ = t.Close()
 	}()
 
 	untar := testUntarFns[untarFn]

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -31,7 +31,8 @@ func TestGenerateEmptyFile(t *testing.T) {
 		}
 		assert.NilError(t, err)
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(tr)
+		_, err = buf.ReadFrom(tr)
+		assert.NilError(t, err)
 		content := buf.String()
 		actualFiles = append(actualFiles, []string{hdr.Name, content})
 		i++
@@ -72,7 +73,8 @@ func TestGenerateWithContent(t *testing.T) {
 		}
 		assert.NilError(t, err)
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(tr)
+		_, err = buf.ReadFrom(tr)
+		assert.NilError(t, err)
 		content := buf.String()
 		actualFiles = append(actualFiles, []string{hdr.Name, content})
 		i++

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"archive/tar"
 	"bytes"
+	"errors"
 	"io"
 	"testing"
 
@@ -25,7 +26,7 @@ func TestGenerateEmptyFile(t *testing.T) {
 	i := 0
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		assert.NilError(t, err)
@@ -66,7 +67,7 @@ func TestGenerateWithContent(t *testing.T) {
 	i := 0
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		assert.NilError(t, err)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49757


fix "struct literal uses unkeyed fields" (govet), and rename a function to prevent shadowing.

    pkg/archive/changes_test.go:123:18: composites: github.com/docker/docker/pkg/archive.Change struct literal uses unkeyed fields (govet)
        modifyChange := Change{"change", ChangeModify}
                        ^
    pkg/archive/changes_test.go:128:15: composites: github.com/docker/docker/pkg/archive.Change struct literal uses unkeyed fields (govet)
        addChange := Change{"change", ChangeAdd}
                     ^
    ...