### PR TITLE
use wrapper function instead of variable for freebsd

### DIFF
--- a/dev_freebsd.go
+++ b/dev_freebsd.go
@@ -4,4 +4,6 @@ package archive
 
 import "golang.org/x/sys/unix"
 
-var mknod = unix.Mknod
+func mknod(path string, mode uint32, dev uint64) error {
+	return unix.Mknod(path, mode, dev)
+}


### PR DESCRIPTION
This variable made me look various times to find if it was (e.g.) needed to stub out the function in (unit)tests, but it looks like it was only there for convenience (not having to define a function).

Let's change it to a regular function that wraps the underlying implementation to prevent this confusion.