### PR TITLE
move FileInfoHeaderNoLookups to separate tarheader package

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -20,6 +20,7 @@ import (
 	"github.com/moby/sys/user"
 
 	"github.com/moby/go-archive/compression"
+	"github.com/moby/go-archive/tarheader"
 )
 
 // ImpliedDirectoryMode represents the mode (Unix permissions) applied to directories that are implied by files in a
@@ -234,71 +235,11 @@ func ReplaceFileTarWrapper(inputTarStream io.ReadCloser, mods map[string]TarModi
 	return pipeReader
 }
 
-// assert that we implement [tar.FileInfoNames].
-var _ tar.FileInfoNames = (*nosysFileInfo)(nil)
-
-// nosysFileInfo hides the system-dependent info of the wrapped FileInfo to
-// prevent tar.FileInfoHeader from introspecting it and potentially calling into
-// glibc.
-//
-// It implements [tar.FileInfoNames] to further prevent [tar.FileInfoHeader]
-// from performing any lookups on go1.23 and up. see https://go.dev/issue/50102
-type nosysFileInfo struct {
-	os.FileInfo
-}
-
-// Uname stubs out looking up username. It implements [tar.FileInfoNames]
-// to prevent [tar.FileInfoHeader] from loading libraries to perform
-// username lookups.
-func (fi nosysFileInfo) Uname() (string, error) {
-	return "", nil
-}
-
-// Gname stubs out looking up group-name. It implements [tar.FileInfoNames]
-// to prevent [tar.FileInfoHeader] from loading libraries to perform
-// username lookups.
-func (fi nosysFileInfo) Gname() (string, error) {
-	return "", nil
-}
-
-func (fi nosysFileInfo) Sys() interface{} {
-	// A Sys value of type *tar.Header is safe as it is system-independent.
-	// The tar.FileInfoHeader function copies the fields into the returned
-	// header without performing any OS lookups.
-	if sys, ok := fi.FileInfo.Sys().(*tar.Header); ok {
-		return sys
-	}
-	return nil
-}
-
-// sysStat, if non-nil, populates hdr from system-dependent fields of fi.
-var sysStat func(fi os.FileInfo, hdr *tar.Header) error
-
 // FileInfoHeaderNoLookups creates a partially-populated tar.Header from fi.
 //
-// Compared to the archive/tar.FileInfoHeader function, this function is safe to
-// call from a chrooted process as it does not populate fields which would
-// require operating system lookups. It behaves identically to
-// tar.FileInfoHeader when fi is a FileInfo value returned from
-// tar.Header.FileInfo().
-//
-// When fi is a FileInfo for a native file, such as returned from os.Stat() and
-// os.Lstat(), the returned Header value differs from one returned from
-// tar.FileInfoHeader in the following ways. The Uname and Gname fields are not
-// set as OS lookups would be required to populate them. The AccessTime and
-// ChangeTime fields are not currently set (not yet implemented) although that
-// is subject to change. Callers which require the AccessTime or ChangeTime
-// fields to be zeroed should explicitly zero them out in the returned Header
-// value to avoid any compatibility issues in the future.
+// Deprecated: use [tarheader.FileInfoHeaderNoLookups].
 func FileInfoHeaderNoLookups(fi os.FileInfo, link string) (*tar.Header, error) {
-	hdr, err := tar.FileInfoHeader(nosysFileInfo{fi}, link)
-	if err != nil {
-		return nil, err
-	}
-	if sysStat != nil {
-		return hdr, sysStat(fi, hdr)
-	}
-	return hdr, nil
+	return tarheader.FileInfoHeaderNoLookups(fi, link)
 }
 
 // FileInfoHeader creates a populated Header from fi.
@@ -309,7 +250,7 @@ func FileInfoHeaderNoLookups(fi os.FileInfo, link string) (*tar.Header, error) {
 // precision, and the Uname and Gname fields are only set when fi is a FileInfo
 // value returned from tar.Header.FileInfo().
 func FileInfoHeader(name string, fi os.FileInfo, link string) (*tar.Header, error) {
-	hdr, err := FileInfoHeaderNoLookups(fi, link)
+	hdr, err := tarheader.FileInfoHeaderNoLookups(fi, link)
 	if err != nil {
 		return nil, err
 	}
@@ -1177,7 +1118,7 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 			}
 			defer srcF.Close()
 
-			hdr, err := FileInfoHeaderNoLookups(srcSt, "")
+			hdr, err := tarheader.FileInfoHeaderNoLookups(srcSt, "")
 			if err != nil {
 				return err
 			}

--- a/archive_test.go
+++ b/archive_test.go
@@ -1123,12 +1123,3 @@ func readFileFromArchive(t *testing.T, archive io.ReadCloser, name string, expec
 	assert.Check(t, err)
 	return string(content)
 }
-
-func TestNosysFileInfo(t *testing.T) {
-	st, err := os.Stat("archive_test.go")
-	assert.NilError(t, err)
-	h, err := tar.FileInfoHeader(nosysFileInfo{st}, "")
-	assert.NilError(t, err)
-	assert.Check(t, h.Uname == "")
-	assert.Check(t, h.Gname == "")
-}

--- a/tarheader/tarheader.go
+++ b/tarheader/tarheader.go
@@ -42,9 +42,6 @@ func (fi nosysFileInfo) Sys() interface{} {
 	return nil
 }
 
-// sysStat, if non-nil, populates hdr from system-dependent fields of fi.
-var sysStat func(fi os.FileInfo, hdr *tar.Header) error
-
 // FileInfoHeaderNoLookups creates a partially-populated tar.Header from fi.
 //
 // Compared to the archive/tar.FileInfoHeader function, this function is safe to
@@ -66,8 +63,5 @@ func FileInfoHeaderNoLookups(fi os.FileInfo, link string) (*tar.Header, error) {
 	if err != nil {
 		return nil, err
 	}
-	if sysStat != nil {
-		return hdr, sysStat(fi, hdr)
-	}
-	return hdr, nil
+	return hdr, sysStat(fi, hdr)
 }

--- a/tarheader/tarheader.go
+++ b/tarheader/tarheader.go
@@ -1,0 +1,73 @@
+package tarheader
+
+import (
+	"archive/tar"
+	"os"
+)
+
+// assert that we implement [tar.FileInfoNames].
+var _ tar.FileInfoNames = (*nosysFileInfo)(nil)
+
+// nosysFileInfo hides the system-dependent info of the wrapped FileInfo to
+// prevent tar.FileInfoHeader from introspecting it and potentially calling into
+// glibc.
+//
+// It implements [tar.FileInfoNames] to further prevent [tar.FileInfoHeader]
+// from performing any lookups on go1.23 and up. see https://go.dev/issue/50102
+type nosysFileInfo struct {
+	os.FileInfo
+}
+
+// Uname stubs out looking up username. It implements [tar.FileInfoNames]
+// to prevent [tar.FileInfoHeader] from loading libraries to perform
+// username lookups.
+func (fi nosysFileInfo) Uname() (string, error) {
+	return "", nil
+}
+
+// Gname stubs out looking up group-name. It implements [tar.FileInfoNames]
+// to prevent [tar.FileInfoHeader] from loading libraries to perform
+// username lookups.
+func (fi nosysFileInfo) Gname() (string, error) {
+	return "", nil
+}
+
+func (fi nosysFileInfo) Sys() interface{} {
+	// A Sys value of type *tar.Header is safe as it is system-independent.
+	// The tar.FileInfoHeader function copies the fields into the returned
+	// header without performing any OS lookups.
+	if sys, ok := fi.FileInfo.Sys().(*tar.Header); ok {
+		return sys
+	}
+	return nil
+}
+
+// sysStat, if non-nil, populates hdr from system-dependent fields of fi.
+var sysStat func(fi os.FileInfo, hdr *tar.Header) error
+
+// FileInfoHeaderNoLookups creates a partially-populated tar.Header from fi.
+//
+// Compared to the archive/tar.FileInfoHeader function, this function is safe to
+// call from a chrooted process as it does not populate fields which would
+// require operating system lookups. It behaves identically to
+// tar.FileInfoHeader when fi is a FileInfo value returned from
+// tar.Header.FileInfo().
+//
+// When fi is a FileInfo for a native file, such as returned from os.Stat() and
+// os.Lstat(), the returned Header value differs from one returned from
+// tar.FileInfoHeader in the following ways. The Uname and Gname fields are not
+// set as OS lookups would be required to populate them. The AccessTime and
+// ChangeTime fields are not currently set (not yet implemented) although that
+// is subject to change. Callers which require the AccessTime or ChangeTime
+// fields to be zeroed should explicitly zero them out in the returned Header
+// value to avoid any compatibility issues in the future.
+func FileInfoHeaderNoLookups(fi os.FileInfo, link string) (*tar.Header, error) {
+	hdr, err := tar.FileInfoHeader(nosysFileInfo{fi}, link)
+	if err != nil {
+		return nil, err
+	}
+	if sysStat != nil {
+		return hdr, sysStat(fi, hdr)
+	}
+	return hdr, nil
+}

--- a/tarheader/tarheader_test.go
+++ b/tarheader/tarheader_test.go
@@ -1,0 +1,24 @@
+package tarheader
+
+import (
+	"archive/tar"
+	"os"
+	"testing"
+)
+
+func TestNosysFileInfo(t *testing.T) {
+	st, err := os.Stat("tarheader_test.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := tar.FileInfoHeader(nosysFileInfo{st}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Uname != "" {
+		t.Errorf("uname should be empty; got %v", h.Uname)
+	}
+	if h.Gname != "" {
+		t.Errorf("gname should be empty; got %v", h.Uname)
+	}
+}

--- a/tarheader/tarheader_unix.go
+++ b/tarheader/tarheader_unix.go
@@ -1,0 +1,50 @@
+//go:build !windows
+
+package tarheader
+
+import (
+	"archive/tar"
+	"os"
+	"runtime"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	sysStat = statUnix
+}
+
+// statUnix populates hdr from system-dependent fields of fi without performing
+// any OS lookups.
+func statUnix(fi os.FileInfo, hdr *tar.Header) error {
+	// Devmajor and Devminor are only needed for special devices.
+
+	// In FreeBSD, RDev for regular files is -1 (unless overridden by FS):
+	// https://cgit.freebsd.org/src/tree/sys/kern/vfs_default.c?h=stable/13#n1531
+	// (NODEV is -1: https://cgit.freebsd.org/src/tree/sys/sys/param.h?h=stable/13#n241).
+
+	// ZFS in particular does not override the default:
+	// https://cgit.freebsd.org/src/tree/sys/contrib/openzfs/module/os/freebsd/zfs/zfs_vnops_os.c?h=stable/13#n2027
+
+	// Since `Stat_t.Rdev` is uint64, the cast turns -1 into (2^64 - 1).
+	// Such large values cannot be encoded in a tar header.
+	if runtime.GOOS == "freebsd" && hdr.Typeflag != tar.TypeBlock && hdr.Typeflag != tar.TypeChar {
+		return nil
+	}
+	s, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+
+	hdr.Uid = int(s.Uid)
+	hdr.Gid = int(s.Gid)
+
+	if s.Mode&unix.S_IFBLK != 0 ||
+		s.Mode&unix.S_IFCHR != 0 {
+		hdr.Devmajor = int64(unix.Major(uint64(s.Rdev))) //nolint: unconvert
+		hdr.Devminor = int64(unix.Minor(uint64(s.Rdev))) //nolint: unconvert
+	}
+
+	return nil
+}

--- a/tarheader/tarheader_unix.go
+++ b/tarheader/tarheader_unix.go
@@ -11,13 +11,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func init() {
-	sysStat = statUnix
-}
-
-// statUnix populates hdr from system-dependent fields of fi without performing
+// sysStat populates hdr from system-dependent fields of fi without performing
 // any OS lookups.
-func statUnix(fi os.FileInfo, hdr *tar.Header) error {
+func sysStat(fi os.FileInfo, hdr *tar.Header) error {
 	// Devmajor and Devminor are only needed for special devices.
 
 	// In FreeBSD, RDev for regular files is -1 (unless overridden by FS):

--- a/tarheader/tarheader_windows.go
+++ b/tarheader/tarheader_windows.go
@@ -1,0 +1,12 @@
+package tarheader
+
+import (
+	"archive/tar"
+	"os"
+)
+
+// sysStat populates hdr from system-dependent fields of fi without performing
+// any OS lookups. It is a no-op on Windows.
+func sysStat(os.FileInfo, *tar.Header) error {
+	return nil
+}


### PR DESCRIPTION
This aligns with how containerd organizes the code, and allows consuming this function without requiring all the other code.