### PR TITLE
TestOverlayTarUntar: remove redundant cmpopts.EquateEmpty

### DIFF
--- a/archive_linux_test.go
+++ b/archive_linux_test.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/sys/userns"
 	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
@@ -124,7 +123,7 @@ func TestOverlayTarUntar(t *testing.T) {
 		}
 		assert.NilError(t, err)
 		assert.Check(t, is.Equal(h.Devmajor, int64(0)), "unexpected device file in archive")
-		assert.Check(t, is.DeepEqual(h.PAXRecords, map[string]string(nil), cmpopts.EquateEmpty()))
+		assert.Check(t, is.DeepEqual(h.PAXRecords, map[string]string(nil)))
 		entries[h.Name] = struct{}{}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.23.0
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6
 	github.com/containerd/log v0.1.0
-	github.com/google/go-cmp v0.7.0
 	github.com/klauspost/compress v1.18.0
 	github.com/moby/patternmatcher v0.6.0
 	github.com/moby/sys/mount v0.3.4
@@ -18,4 +17,7 @@ require (
 	gotest.tools/v3 v3.5.2
 )
 
-require github.com/sirupsen/logrus v1.9.3 // indirect
+require (
+	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
+)


### PR DESCRIPTION
It looks like this option was added as an extra condition to prevent possibly "nil" vs "empty" false-positives, but the test looks to be happy without; we can add it back if it's causing issues, but let's remove to remove github.com/google/go-cmp as a direct dependency.

Relates to https://github.com/moby/moby/commit/6a8a79201954875ad97a6835d4c9db95935ac98f