### PR TITLE
chrootarchive: remove redundant "init" mitigation for CVE-2019-14271

### DIFF
--- a/chrootarchive/archive_unix.go
+++ b/chrootarchive/archive_unix.go
@@ -5,20 +5,11 @@ package chrootarchive
 import (
 	"errors"
 	"io"
-	"net"
-	"os/user"
 	"path/filepath"
 	"strings"
 
 	"github.com/moby/go-archive"
 )
-
-func init() {
-	// initialize nss libraries in Glibc so that the dynamic libraries are loaded in the host
-	// environment not in the chroot from untrusted files.
-	_, _ = user.Lookup("docker")
-	_, _ = net.LookupHost("localhost")
-}
 
 func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.TarOptions, root string) error {
 	relDest, err := resolvePathInChroot(root, dest)


### PR DESCRIPTION
relates to;

- closes https://github.com/moby/moby/issues/44540
- closes https://github.com/docker/for-linux/issues/269
- relates to https://github.com/moby/moby/pull/39612
- relates to https://github.com/moby/moby/pull/49152
- relates to https://github.com/golang/go/issues/50102




This init wasa added in [moby@a316b10] to prevent libraries being loaded in memory from an untrusted environment. Later mitigations added in [moby@e9bbc41], and [moby@2b4db93] (following implementation of https://go.dev/issue/50102 in go1.23) made this init redundant, but the original patch was left in-place.

In some situations, this init can cause delays, resulting in slow starts of containers;

    dockerd[165807]: init github.com/docker/docker/pkg/chrootarchive @11 ms, 20013 ms clock, 147808 bytes, 131 allocs

Further looking into the mitigation, it's debatable if the defence-in-depth adds much value (see [1]);

> From my point of view, the original fix (func init()) is only a workaround
> instead of a proper fix (avoid populating user/group names). NSS loads DSOs
> lazily, user.Lookup("docker") and net.LookupHost("localhost") can not guarantee
> every DSOs are loaded.
>
> For example, in a sane environment (/etc/hosts contains an entry for localhost),
> net.LookupHost("localhost") stops at libnss_files.so and will not load libnss_dns.so,
> which makes it almost useless because libnss_files.so was already loaded due
> to user.Lookup("docker").

This patch removes the init to prevent the possibility of adding delays, and because this mitigation became redundant.

[moby@a316b10]: https://github.com/moby/moby/commit/a316b10dab79d9298b02c7930958ed52e0ccf4e4
[moby@e9bbc41]: https://github.com/moby/moby/commit/e9bbc41dd146d692e28660a392b068c9c112f2ad
[moby@2b4db93]: https://github.com/moby/moby/commit/2b4db9383c5136bbfb2d695a90b169a27a738730
[1]: https://github.com/moby/moby/issues/44540#issuecomment-1354199004

