### PR TITLE
un-skip tests on Windows V19H1 (1903) and up

### DIFF
--- a/changes_test.go
+++ b/changes_test.go
@@ -245,10 +245,6 @@ func TestChangesWithChangesGH13590(t *testing.T) {
 
 // Create a directory, copy it, make sure we report no changes between the two
 func TestChangesDirsEmpty(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("FIXME: broken on Windows 1903 and up; see https://github.com/moby/moby/pull/39846")
-	}
-
 	src, err := os.MkdirTemp("", "docker-changes-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(src)
@@ -331,10 +327,6 @@ func mutateSampleDir(t *testing.T, root string) {
 }
 
 func TestChangesDirsMutated(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("FIXME: broken on Windows 1903 and up; see https://github.com/moby/moby/pull/39846")
-	}
-
 	src, err := os.MkdirTemp("", "docker-changes-test")
 	assert.NilError(t, err)
 	createSampleDir(t, src)


### PR DESCRIPTION
- moving https://github.com/moby/moby/pull/48004
- relates to https://github.com/moby/moby/pull/39846
- relates to https://github.com/moby/moby/pull/48005
- relates to https://github.com/moby/moby/issues/21700

This re-enables TestChangesDirsEmpty and TestChangesDirsMutated on current Windows versions. These tests were failing on Windows V19H1 (1903) and up, possibly due to changes in the kernel, and were skipped in commit 8f4b3b0ad41a5e3a29e57f0a8c55cb49e7a0b44f;

    === FAIL: github.com/docker/docker/pkg/archive TestChangesDirsEmpty (0.21s)
        changes_test.go:261: Reported changes for identical dirs: [{\dirSymlink C}]

    === FAIL: github.com/docker/docker/pkg/archive TestChangesDirsMutated (0.14s)
        changes_test.go:391: unexpected change "C \\dirSymlink" "\\dirnew"

This reverts commit 8f4b3b0ad41a5e3a29e57f0a8c55cb49e7a0b44f. This reverts commit 3108165c94bf48014aa9f412193fe25852f1958f