### PR TITLE
archive: replace static path check with symlink-aware safeResolve

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -844,17 +844,11 @@ loop:
 			continue
 		}
 
-		// Normalize name: root with "/" to eliminate leading ".."
-		// components, then strip the leading "/" for a root-relative path.
-		hdr.Name = strings.TrimLeft(path.Join("/", hdr.Name), "/")
-		if hdr.Name == "" {
-			hdr.Name = "."
-		}
-		// Defence-in-depth: reject any name that, after normalisation,
-		// would still resolve outside the extraction root (absolute, empty,
-		// or containing ".." components). This should be unreachable after
-		// the normalisation above; it also serves as an explicit sanitiser
-		// that static analysers recognise.
+		// Strip a leading "/" so absolute entries stay root-relative, then
+		// Clean while keeping any ".." so the IsLocal check below rejects
+		// escapes instead of silently rewriting them.
+		hdr.Name = path.Clean(strings.TrimLeft(hdr.Name, "/"))
+		// Reject names that escape the extraction root (absolute or "..").
 		if !filepath.IsLocal(hdr.Name) {
 			return breakoutError(fmt.Errorf("invalid entry name %q", hdr.Name))
 		}

--- a/archive.go
+++ b/archive.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -470,12 +471,17 @@ func createTarFile(dstPath, extractDir string, hdr *tar.Header, reader io.Reader
 		}
 
 	case tar.TypeLink:
-		// #nosec G305 -- The target path is checked for path traversal.
-		linkTarget := filepath.Join(extractDir, hdr.Linkname)
-		// check for hardlink breakout
-		if !strings.HasPrefix(linkTarget, extractDir) {
-			return breakoutError(fmt.Errorf("invalid hardlink %q -> %q", linkTarget, hdr.Linkname))
+		// Resolve only the parent directory of the hardlink target through
+		// any symlinks within extractDir to prevent escape via path
+		// traversal. The final component is not dereferenced so the
+		// hardlink references the literal node, matching link(2) semantics
+		// (a hardlink whose source is a symlink references the symlink
+		// inode itself, not its target).
+		targetDir, err := safeResolve(extractDir, filepath.Dir(hdr.Linkname))
+		if err != nil {
+			return err
 		}
+		linkTarget := filepath.Join(targetDir, filepath.Base(hdr.Linkname))
 		if err := os.Link(linkTarget, dstPath); err != nil {
 			return err
 		}
@@ -806,11 +812,18 @@ func (t *Tarballer) Do() {
 	}
 }
 
+// unpackedDir records a directory whose mtime must be restored after all
+// entries are extracted, along with the resolved path used during extraction.
+type unpackedDir struct {
+	hdr  *tar.Header
+	path string
+}
+
 // Unpack unpacks the decompressedArchive to dest with options.
 func Unpack(decompressedArchive io.Reader, dest string, options *TarOptions) error {
 	tr := tar.NewReader(decompressedArchive)
 
-	var dirs []*tar.Header
+	var dirs []unpackedDir
 	whiteoutConverter := getWhiteoutConverter(options.WhiteoutFormat)
 
 	// Iterate through the files in the archive.
@@ -831,10 +844,20 @@ loop:
 			continue
 		}
 
-		// Normalize name, for safety and for a simple is-root check
-		// This keeps "../" as-is, but normalizes "/../" to "/". Or Windows:
-		// This keeps "..\" as-is, but normalizes "\..\" to "\".
-		hdr.Name = filepath.Clean(hdr.Name)
+		// Normalize name: root with "/" to eliminate leading ".."
+		// components, then strip the leading "/" for a root-relative path.
+		hdr.Name = strings.TrimLeft(path.Join("/", hdr.Name), "/")
+		if hdr.Name == "" {
+			hdr.Name = "."
+		}
+		// Defence-in-depth: reject any name that, after normalisation,
+		// would still resolve outside the extraction root (absolute, empty,
+		// or containing ".." components). This should be unreachable after
+		// the normalisation above; it also serves as an explicit sanitiser
+		// that static analysers recognise.
+		if !filepath.IsLocal(hdr.Name) {
+			return breakoutError(fmt.Errorf("invalid entry name %q", hdr.Name))
+		}
 
 		for _, exclude := range options.ExcludePatterns {
 			if strings.HasPrefix(hdr.Name, exclude) {
@@ -848,15 +871,16 @@ loop:
 			return err
 		}
 
-		// #nosec G305 -- The joined path is checked for path traversal.
-		dstPath := filepath.Join(dest, hdr.Name)
-		rel, err := filepath.Rel(dest, dstPath)
+		// Resolve only the parent directory through any symlinks within
+		// dest to prevent path traversal via intermediate components.
+		// The final component is not dereferenced so that entries replace
+		// the node at their literal path (e.g. an existing symlink is
+		// replaced rather than written through to its target).
+		resolvedDir, err := safeResolve(dest, filepath.Dir(hdr.Name))
 		if err != nil {
 			return err
 		}
-		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-			return breakoutError(fmt.Errorf("%q is outside of %q", hdr.Name, dest))
-		}
+		dstPath := filepath.Join(resolvedDir, filepath.Base(hdr.Name))
 
 		// If path exits we almost always just want to remove and replace it
 		// The only exception is when it is a directory *and* the file from
@@ -905,16 +929,15 @@ loop:
 		}
 
 		// Directory mtimes must be handled at the end to avoid further
-		// file creation in them to modify the directory mtime
+		// file creation in them to modify the directory mtime.
 		if hdr.Typeflag == tar.TypeDir {
-			dirs = append(dirs, hdr)
+			dirs = append(dirs, unpackedDir{hdr: hdr, path: path})
 		}
 	}
 
-	for _, hdr := range dirs {
-		// #nosec G305 -- The header was checked for path traversal before it was appended to the dirs slice.
-		dstPath := filepath.Join(dest, hdr.Name)
-		if err := chtimes(dstPath, boundTime(latestTime(hdr.AccessTime, hdr.ModTime)), boundTime(hdr.ModTime)); err != nil {
+	for _, d := range dirs {
+		aTime := boundTime(latestTime(d.hdr.AccessTime, d.hdr.ModTime))
+		if err := chtimes(d.path, aTime, boundTime(d.hdr.ModTime)); err != nil {
 			return err
 		}
 	}
@@ -926,14 +949,20 @@ loop:
 // defined by the paths of files in the tar, but there are no header entries for the directories themselves, and thus
 // we most both create them and choose metadata like permissions.
 //
-// The caller should have performed filepath.Clean(hdr.Name), so hdr.Name will now be in the filepath format for the OS
-// on which the daemon is running. This precondition is required because this function assumes a OS-specific path
-// separator when checking that a path is not the root.
+// The caller must have normalized hdr.Name (no leading ".." components).
 func createImpliedDirectories(dest string, hdr *tar.Header, options *TarOptions) error {
-	// Not the root directory, ensure that the parent directory exists
+	// Not the root directory, ensure that the parent directory exists.
 	if !strings.HasSuffix(hdr.Name, string(os.PathSeparator)) {
 		parent := filepath.Dir(hdr.Name)
-		parentPath := filepath.Join(dest, parent)
+		// Resolve the parent path through any symlinks within dest. This
+		// bounds the subsequent Lstat and MkdirAllAndChown operations
+		// within dest so a pre-existing or archive-planted symlink in an
+		// intermediate component cannot redirect directory creation
+		// outside the extraction root.
+		parentPath, err := safeResolve(dest, parent)
+		if err != nil {
+			return err
+		}
 		if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
 			// RootPair() is confined inside this loop as most cases will not require a call, so we can spend some
 			// unneeded function calls in the uncommon case to encapsulate logic -- implied directories are a niche

--- a/archive_test.go
+++ b/archive_test.go
@@ -924,6 +924,51 @@ func TestUntarInvalidSymlink(t *testing.T) {
 	}
 }
 
+// TestUntarSymlinkBreakout is a regression test for a tar path-traversal
+// vulnerability: a two-hop symlink chain in a malicious archive can escape
+// the extraction root at runtime while passing the static path checks that
+// guard each entry name and symlink target.  Two hops are needed because a
+// direct out-of-root symlink target is already rejected by a static check in
+// createTarFile; the first hop (go_up -> "..") fools that check for the
+// second hop (escape -> "../victim") by appearing to stay within the root
+// when paths are joined as strings, while the OS resolves go_up at runtime
+// and places escape one level higher than the check assumed.
+func TestUntarSymlinkBreakout(t *testing.T) {
+	tmpdir := t.TempDir()
+	dest := filepath.Join(tmpdir, "dest")
+	victim := filepath.Join(tmpdir, "victim")
+	if err := os.Mkdir(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(victim, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := &bytes.Buffer{}
+	tw := tar.NewWriter(buf)
+	for _, hdr := range []*tar.Header{
+		{Name: "inner", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: "inner/go_up", Typeflag: tar.TypeSymlink, Linkname: ".."},
+		{Name: "inner/go_up/escape", Typeflag: tar.TypeSymlink, Linkname: "../victim"},
+		{Name: "inner/go_up/escape/newfile", Typeflag: tar.TypeReg, Mode: 0o644},
+	} {
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = tw.Close()
+
+	// Ignore any extraction error: a breakoutError means the escape was
+	// caught; no error means the write was safely redirected within dest.
+	// NoLchown suppresses the ownership call so the test runs without root.
+	_ = Untar(buf, dest, &TarOptions{NoLchown: true})
+
+	// victim/newfile must not exist; its presence proves a breakout.
+	if _, err := os.Lstat(filepath.Join(victim, "newfile")); err == nil {
+		t.Fatal("archive breakout: newfile was written outside extraction root via symlink chain")
+	}
+}
+
 func TestTempArchiveCloseMultipleTimes(t *testing.T) {
 	reader := io.NopCloser(strings.NewReader("hello"))
 	tmpArchive, err := newTempArchive(reader, "")

--- a/diff.go
+++ b/diff.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -22,7 +23,7 @@ import (
 func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64, err error) {
 	tr := tar.NewReader(layer)
 
-	var dirs []*tar.Header
+	var dirs []unpackedDir
 	unpackedPaths := make(map[string]struct{})
 
 	if options == nil {
@@ -48,8 +49,20 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 
 		size += hdr.Size
 
-		// Normalize name, for safety and for a simple is-root check
-		hdr.Name = filepath.Clean(hdr.Name)
+		// Normalize name: root with "/" to eliminate leading ".."
+		// components, then strip the leading "/" for a root-relative path.
+		hdr.Name = strings.TrimLeft(path.Join("/", hdr.Name), "/")
+		if hdr.Name == "" {
+			hdr.Name = "."
+		}
+		// Defence-in-depth: reject any name that, after normalisation,
+		// would still resolve outside the extraction root (absolute, empty,
+		// or containing ".." components). This should be unreachable after
+		// the normalisation above; it also serves as an explicit sanitiser
+		// that static analysers recognise.
+		if !filepath.IsLocal(hdr.Name) {
+			return 0, breakoutError(fmt.Errorf("invalid entry name %q", hdr.Name))
+		}
 
 		// Windows does not support filenames with colons in them. Ignore
 		// these files. This is not a problem though (although it might
@@ -101,17 +114,16 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				continue
 			}
 		}
-		// #nosec G305 -- The joined path is guarded against path traversal.
-		dstPath := filepath.Join(dest, hdr.Name)
-		rel, err := filepath.Rel(dest, dstPath)
+		// Resolve only the parent directory through any symlinks within
+		// dest to prevent path traversal via intermediate components.
+		// The final component is not dereferenced so that entries replace
+		// the node at their literal path (e.g. an existing symlink is
+		// replaced rather than written through to its target).
+		resolvedDir, err := safeResolve(dest, filepath.Dir(hdr.Name))
 		if err != nil {
 			return 0, err
 		}
-
-		// Note as these operations are platform specific, so must the slash be.
-		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-			return 0, breakoutError(fmt.Errorf("%q is outside of %q", hdr.Name, dest))
-		}
+		dstPath := filepath.Join(resolvedDir, filepath.Base(hdr.Name))
 		base := filepath.Base(dstPath)
 
 		if strings.HasPrefix(base, WhiteoutPrefix) {
@@ -187,18 +199,16 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			}
 
 			// Directory mtimes must be handled at the end to avoid further
-			// file creation in them to modify the directory mtime
+			// file creation in them to modify the directory mtime.
 			if hdr.Typeflag == tar.TypeDir {
-				dirs = append(dirs, hdr)
+				dirs = append(dirs, unpackedDir{hdr: hdr, path: path})
 			}
 			unpackedPaths[dstPath] = struct{}{}
 		}
 	}
 
-	for _, hdr := range dirs {
-		// #nosec G305 -- The header was checked for path traversal before it was appended to the dirs slice.
-		dstPath := filepath.Join(dest, hdr.Name)
-		if err := chtimes(dstPath, hdr.AccessTime, hdr.ModTime); err != nil {
+	for _, d := range dirs {
+		if err := chtimes(d.path, d.hdr.AccessTime, d.hdr.ModTime); err != nil {
 			return 0, err
 		}
 	}

--- a/diff.go
+++ b/diff.go
@@ -49,17 +49,11 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 
 		size += hdr.Size
 
-		// Normalize name: root with "/" to eliminate leading ".."
-		// components, then strip the leading "/" for a root-relative path.
-		hdr.Name = strings.TrimLeft(path.Join("/", hdr.Name), "/")
-		if hdr.Name == "" {
-			hdr.Name = "."
-		}
-		// Defence-in-depth: reject any name that, after normalisation,
-		// would still resolve outside the extraction root (absolute, empty,
-		// or containing ".." components). This should be unreachable after
-		// the normalisation above; it also serves as an explicit sanitiser
-		// that static analysers recognise.
+		// Strip a leading "/" so absolute entries stay root-relative, then
+		// Clean while keeping any ".." so the IsLocal check below rejects
+		// escapes instead of silently rewriting them.
+		hdr.Name = path.Clean(strings.TrimLeft(hdr.Name, "/"))
+		// Reject names that escape the extraction root (absolute or "..").
 		if !filepath.IsLocal(hdr.Name) {
 			return 0, breakoutError(fmt.Errorf("invalid entry name %q", hdr.Name))
 		}

--- a/safepath.go
+++ b/safepath.go
@@ -1,0 +1,148 @@
+package archive
+
+import (
+	"errors"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+// maxSymlinkDepth is the maximum number of symlinks that safeResolve will
+// follow before returning errTooManyLinks.
+const maxSymlinkDepth = 255
+
+// errTooManyLinks is returned when safeResolve encounters more than
+// maxSymlinkDepth symlinks while resolving a path.
+var errTooManyLinks = errors.New("too many symlinks")
+
+// safeResolve joins p to root, resolving each path component on-disk to
+// detect and bound any symlinks within root. This prevents tar path-traversal
+// attacks where a malicious archive creates a symlink pointing outside root
+// and then writes files through it.
+//
+// Unlike filepath.Join(root, p), safeResolve calls os.Lstat on each path
+// component. When a component is a symlink, its target is resolved relative
+// to root, so absolute symlinks and relative symlinks that escape root are
+// silently redirected to stay within root.
+//
+// Internally safeResolve operates on slash-separated paths so that resolution
+// is consistent across platforms regardless of the input separator. Symlink
+// targets read via os.Readlink are normalised to forward slashes too, and
+// absolute targets — both forward-slash ("/foo") and platform-specific
+// ("C:\foo" on Windows) — are bounded within root.
+//
+// This is ported from github.com/containerd/continuity/fs.RootPath.
+func safeResolve(root, p string) (string, error) {
+	if p == "" {
+		return root, nil
+	}
+	// Normalise the input to forward slashes so that all internal path
+	// operations have consistent semantics on every platform.
+	p = filepath.ToSlash(p)
+	var linksWalked int
+	for {
+		prevLinks := linksWalked
+		newpath, err := walkLinks(root, p, &linksWalked)
+		if err != nil {
+			return "", err
+		}
+		p = newpath
+		if prevLinks == linksWalked {
+			// No new symlinks resolved; bound the path under root and
+			// check for stability.
+			newpath = path.Join("/", newpath)
+			if p == newpath {
+				return filepath.Join(root, filepath.FromSlash(newpath)), nil
+			}
+			p = newpath
+		}
+	}
+}
+
+// walkLinks resolves symlinks in a slash-separated path one component at a
+// time, bounding any symlink targets within root.
+func walkLinks(root, p string, linksWalked *int) (string, error) {
+	dir, file := path.Split(p)
+	switch {
+	case dir == "":
+		newpath, _, err := walkLink(root, file, linksWalked)
+		return newpath, err
+	case file == "":
+		if dir[len(dir)-1] == '/' {
+			if dir == "/" {
+				return dir, nil
+			}
+			// Strip trailing separator and recurse.
+			return walkLinks(root, dir[:len(dir)-1], linksWalked)
+		}
+		newpath, _, err := walkLink(root, dir, linksWalked)
+		return newpath, err
+	default:
+		newdir, err := walkLinks(root, dir, linksWalked)
+		if err != nil {
+			return "", err
+		}
+		newpath, islink, err := walkLink(
+			root, path.Join(newdir, file), linksWalked,
+		)
+		if err != nil {
+			return "", err
+		}
+		if !islink {
+			return newpath, nil
+		}
+		// path.IsAbs only recognises forward-slash absolute paths ("/foo");
+		// filepath.IsAbs additionally catches the platform-specific cases
+		// (e.g. "C:\foo" on Windows). Together they cover both so an
+		// absolute symlink target read on either platform is treated as
+		// absolute regardless of which separator style it uses.
+		if path.IsAbs(newpath) || filepath.IsAbs(newpath) {
+			return newpath, nil
+		}
+		return path.Join(newdir, newpath), nil
+	}
+}
+
+// walkLink checks whether the component at filepath.Join(root, p) is a
+// symlink. If it is, it reads the link target, increments linksWalked, and
+// returns the target. Non-existent components are treated as non-symlinks,
+// which allows safeResolve to be used for paths that do not yet exist.
+//
+// p is a slash-separated path; the returned newpath is also slash-separated.
+func walkLink(root, p string, linksWalked *int) (newpath string, islink bool, err error) {
+	if *linksWalked > maxSymlinkDepth {
+		return "", false, errTooManyLinks
+	}
+
+	// Normalise to a slash-rooted path so that filepath.Join(root, p)
+	// never escapes root regardless of whether p is absolute or relative.
+	p = path.Join("/", p)
+	if p == "/" {
+		return p, false, nil
+	}
+	realPath := filepath.Join(root, filepath.FromSlash(p))
+
+	fi, err := os.Lstat(realPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// The component does not exist yet; treat as a non-symlink so
+			// that safeResolve works for paths being created for the first
+			// time.
+			return p, false, nil
+		}
+		return "", false, err
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return p, false, nil
+	}
+
+	target, err := os.Readlink(realPath)
+	if err != nil {
+		return "", false, err
+	}
+	*linksWalked++
+	// Normalise the link target to forward slashes for consistent internal
+	// processing; on Windows os.Readlink may return backslash-separated
+	// paths.
+	return filepath.ToSlash(target), true, nil
+}


### PR DESCRIPTION
## Summary

A malicious tar archive can escape the extraction root by planting a
symlink chain that passes static string-based path checks but resolves
outside the root at runtime. `Unpack` and `UnpackLayer` validated entry
paths using `filepath.Join` + `filepath.Rel`, which does not follow
symlinks on disk. A two-hop chain (an in-root symlink to `..` followed
by a second symlink whose target appears safe statically but escapes
after the first hop is resolved) bypasses both the entry-name check and
the existing symlink-target check in `createTarFile`.

On Linux this is mitigated by `chrootarchive` wrapping extraction in
`chroot(2)`. On platforms without chroot support (Windows) and for
callers that bypass `chrootarchive` (e.g. BuildKit `ADD --unpack`),
the extraction root was not enforced.

This PR introduces `safeResolve` (ported from
`containerd/continuity/fs.RootPath`), which walks each path component
with `os.Lstat` and resolves symlinks within the extraction root,
bounding any targets that would escape back inside it.

Applied to:
- `Unpack`: main path computation and deferred directory `chtimes` loop
- `UnpackLayer`: same
- `createTarFile` `TypeLink`: hardlink target resolution

## Test plan

- [ ] `go test ./...` passes
- [ ] `TestUntarSymlinkBreakout` fails on the pre-fix code (confirmed
  locally): a two-hop symlink chain (`inner/go_up -> ".."`,
  `inner/go_up/escape -> "../victim"`) bypasses both the entry-name
  check and the existing symlink-target check in `createTarFile`, but
  is blocked by `safeResolve`