### PR TITLE
build: bump minimum Go version to 1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.23.x      # oldest supported (see go.mod)
+          - 1.24.x      # oldest supported (see go.mod)
           - oldstable
           - stable
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moby/go-archive
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6


### PR DESCRIPTION
`os.Root`, used to bound all tar extraction operations within the extraction root at the kernel level using `openat(2)` semantics, was introduced in Go 1.24. We will use it in a follow-up PR. Therefore, update `go.mod` and the CI test matrix to require 1.24 as the oldest supported version.