### PR TITLE
build: bump minimum Go version to 1.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.24.x      # oldest supported (see go.mod)
+          - 1.25.x      # oldest supported (see go.mod)
           - oldstable
           - stable
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moby/go-archive
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6


### PR DESCRIPTION
The os.Root methods Link, Lchown, Chtimes, RemoveAll, and Chmod used for bounded tar extraction (introduced in the following commit) were added in Go 1.25, not 1.24. The earlier bump to 1.24 was sufficient for os.OpenRoot itself but not for the extended *os.Root API used here.

Update go.mod and the CI test matrix to require 1.25 as the oldest supported version.