### PR TITLE
ci: use go.mod for "minimum" Go version, and use custom name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,11 @@ permissions:
 
 jobs:
   build:
+    name: ${{ matrix.os }} / ${{ matrix.go-version || 'minimum' }}
     strategy:
       matrix:
         go-version:
-          - 1.25.x      # oldest supported (see go.mod)
+          - "" # leave empty to use go-version-file (use go.mod); see https://github.com/actions/setup-go/issues/450#issuecomment-3620402646
           - oldstable
           - stable
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -29,6 +30,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod # used when go-version is empty.
 
       - name: lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moby/go-archive
 
-go 1.25.0
+go 1.25
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6


### PR DESCRIPTION
actions/setup-go falls back to the configured "go-version-file" if the "go-version" is empty; this allows using the version defined in go.mod to be used for the minimum supported version.

also specify a custom name instead of the actual go version, so that branch protection rules don't have to be updated if the go version changes.

this patch also drops the patch version from go.mod