### PR TITLE
archive: emit tar TypeLink entries for hardlinks on Windows

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -316,21 +316,23 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 		return err
 	}
 
-	// if it's not a directory and has more than 1 link,
-	// it's hard linked, so set the type flag accordingly
-	if !fi.IsDir() && hasHardlinks(fi) {
-		inode, err := getInodeFromStat(fi.Sys())
+	// if it's not a directory and has more than 1 link, it's hard linked,
+	// so set the type flag accordingly.
+	if !fi.IsDir() {
+		multiLink, inode, err := hardlinkInfo(path, fi)
 		if err != nil {
 			return err
 		}
-		// a link should have a name that it links too
-		// and that linked name should be first in the tar archive
-		if oldpath, ok := ta.SeenFiles[inode]; ok {
-			hdr.Typeflag = tar.TypeLink
-			hdr.Linkname = oldpath
-			hdr.Size = 0 // This Must be here for the writer math to add up!
-		} else {
-			ta.SeenFiles[inode] = name
+		if multiLink {
+			// a link should have a name that it links too
+			// and that linked name should be first in the tar archive
+			if oldpath, ok := ta.SeenFiles[inode]; ok {
+				hdr.Typeflag = tar.TypeLink
+				hdr.Linkname = oldpath
+				hdr.Size = 0 // This Must be here for the writer math to add up!
+			} else {
+				ta.SeenFiles[inode] = name
+			}
 		}
 	}
 

--- a/archive_hardlink_test.go
+++ b/archive_hardlink_test.go
@@ -1,0 +1,85 @@
+package archive
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestHardlinkInfoSingleLink(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file")
+	err := os.WriteFile(path, []byte("hello"), 0o644)
+	assert.NilError(t, err)
+
+	fi, err := os.Lstat(path)
+	assert.NilError(t, err)
+
+	multiLink, _, err := hardlinkInfo(path, fi)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(multiLink, false))
+}
+
+func TestHardlinkInfoMultiLink(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+
+	err := os.WriteFile(a, []byte("hello"), 0o644)
+	assert.NilError(t, err)
+
+	if err := os.Link(a, b); err != nil {
+		t.Skipf("skipping; hardlinks unsupported on this filesystem: %v", err)
+	}
+
+	fiA, err := os.Lstat(a)
+	assert.NilError(t, err)
+	fiB, err := os.Lstat(b)
+	assert.NilError(t, err)
+
+	multiA, idA, err := hardlinkInfo(a, fiA)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(multiA, true))
+
+	multiB, idB, err := hardlinkInfo(b, fiB)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(multiB, true))
+
+	// both paths refer to the same underlying file, so the SeenFiles key
+	// must match
+	assert.Check(t, is.Equal(idA, idB))
+}
+
+func TestHardlinkInfoDistinctFiles(t *testing.T) {
+	dir := t.TempDir()
+	a1 := filepath.Join(dir, "a1")
+	a2 := filepath.Join(dir, "a2")
+	b1 := filepath.Join(dir, "b1")
+	b2 := filepath.Join(dir, "b2")
+
+	for _, p := range []string{a1, b1} {
+		err := os.WriteFile(p, []byte("x"), 0o644)
+		assert.NilError(t, err)
+	}
+	if err := os.Link(a1, a2); err != nil {
+		t.Skipf("skipping; hardlinks unsupported on this filesystem: %v", err)
+	}
+	err := os.Link(b1, b2)
+	assert.NilError(t, err)
+
+	fiA, err := os.Lstat(a1)
+	assert.NilError(t, err)
+	fiB, err := os.Lstat(b1)
+	assert.NilError(t, err)
+
+	_, idA, err := hardlinkInfo(a1, fiA)
+	assert.NilError(t, err)
+	_, idB, err := hardlinkInfo(b1, fiB)
+	assert.NilError(t, err)
+
+	// two independent hardlink groups must produce different keys
+	assert.Check(t, idA != idB, "expected distinct SeenFiles keys, got %d for both", idA)
+}

--- a/archive_unix.go
+++ b/archive_unix.go
@@ -42,6 +42,19 @@ func getInodeFromStat(stat interface{}) (uint64, error) {
 	return s.Ino, nil
 }
 
+// hardlinkInfo reports whether fi refers to a file with more than one hard
+// link, and returns an identifier suitable as a SeenFiles key.
+func hardlinkInfo(_ string, fi os.FileInfo) (bool, uint64, error) {
+	if !hasHardlinks(fi) {
+		return false, 0, nil
+	}
+	inode, err := getInodeFromStat(fi.Sys())
+	if err != nil {
+		return false, 0, err
+	}
+	return true, inode, nil
+}
+
 func getFileUIDGID(stat interface{}) (int, int, error) {
 	s, ok := stat.(*syscall.Stat_t)
 

--- a/archive_windows.go
+++ b/archive_windows.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/sys/windows"
 )
 
 // longPathPrefix is the longpath prefix for Windows file paths.
@@ -59,4 +61,40 @@ func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
 func getFileUIDGID(stat interface{}) (int, int, error) {
 	// no notion of file ownership mapping yet on Windows
 	return 0, 0, nil
+}
+
+// hardlinkInfo reports whether path refers to a file with more than one hard
+// link, and returns an identifier suitable as a SeenFiles key. The data
+// exposed via os.FileInfo.Sys() does not include NumberOfLinks or the file
+// ID, so the file is opened and GetFileInformationByHandle is called
+// directly.
+func hardlinkInfo(path string, _ os.FileInfo) (multiLink bool, id uint64, err error) {
+	p, err := windows.UTF16PtrFromString(addLongPathPrefix(path))
+	if err != nil {
+		return false, 0, err
+	}
+	h, err := windows.CreateFile(
+		p,
+		0, // no access required to call GetFileInformationByHandle
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return false, 0, err
+	}
+	defer windows.CloseHandle(h)
+
+	var bhfi windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(h, &bhfi); err != nil {
+		return false, 0, err
+	}
+	if bhfi.NumberOfLinks <= 1 {
+		return false, 0, nil
+	}
+	id = (uint64(bhfi.FileIndexHigh) << 32) | uint64(bhfi.FileIndexLow)
+	id ^= uint64(bhfi.VolumeSerialNumber)
+	return true, id, nil
 }


### PR DESCRIPTION
addTarFile relied on os.FileInfo to detect hardlinks, but on Windows FileInfo.Sys() does not expose NumberOfLinks or a file identifier, so hasHardlinks always returned false and every link was emitted as a full file copy. This inflated tar streams and broke hardlink preservation on extract.

Factor the detection into a hardlinkInfo helper. The Unix implementation wraps the existing stat-based path. The Windows implementation opens the file and calls GetFileInformationByHandle to read NumberOfLinks and the volume/file ID, which are combined into a stable SeenFiles key.

Add cross-platform tests covering the single-link, multi-link, and distinct-group cases.

Signed-off-by: Varun Gokulnath vagokuln@microsoft.com