### PR TITLE
Confine symlinks to root during Windows unpack

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -70,6 +70,14 @@ type (
 		// were probably in the archive for a reason, so set this option at
 		// your own peril.
 		BestEffortXattrs bool
+		// ConfineSymlinksToRoot scope-confines symlink resolution to the
+		// extraction root during unpack, emulating the containment a chroot
+		// provides. It is set by the chrootarchive subpackage on Windows, where
+		// there is no chroot (see moby/moby#47107): an "escaping" symlink is
+		// created rather than rejected, and any entry written through it is
+		// resolved back inside the root instead of breaking out. It has no
+		// effect on packing.
+		ConfineSymlinksToRoot bool
 	}
 )
 
@@ -406,6 +414,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 	var (
 		Lchown                     = true
 		inUserns, bestEffortXattrs bool
+		confineSymlinks            bool
 		chownOpts                  *ChownOpts
 	)
 
@@ -415,6 +424,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 		inUserns = opts.InUserNS // TODO(thaJeztah): consider deprecating opts.InUserNS and detect locally.
 		chownOpts = opts.ChownOpts
 		bestEffortXattrs = opts.BestEffortXattrs
+		confineSymlinks = opts.ConfineSymlinksToRoot
 	}
 
 	// hdr.Mode is in linux format, which we can use for sycalls,
@@ -484,7 +494,11 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, o
 
 		// the reason we don't need to check symlinks in the path (with FollowSymlinkInScope) is because
 		// that symlink would first have to be created, which would be caught earlier, at this very check:
-		if !strings.HasPrefix(targetPath, extractDir) {
+		//
+		// When confineSymlinks is set (chrootarchive on Windows), an escaping
+		// symlink is created rather than rejected; secureJoinScope keeps writes
+		// through it contained, emulating the Linux chroot behaviour.
+		if !confineSymlinks && !strings.HasPrefix(targetPath, extractDir) {
 			return breakoutError(fmt.Errorf("invalid symlink %q -> %q", path, hdr.Linkname))
 		}
 		if err := os.Symlink(hdr.Linkname, path); err != nil {
@@ -845,8 +859,18 @@ loop:
 			return err
 		}
 
-		// #nosec G305 -- The joined path is checked for path traversal.
-		path := filepath.Join(dest, hdr.Name)
+		// #nosec G305 -- The joined path is checked for path traversal below;
+		// when ConfineSymlinksToRoot is set, symlink components are additionally
+		// resolved in scope so writes cannot escape dest (secureJoinScope).
+		var path string
+		if options.ConfineSymlinksToRoot {
+			path, err = secureJoinScope(dest, hdr.Name)
+			if err != nil {
+				return err
+			}
+		} else {
+			path = filepath.Join(dest, hdr.Name)
+		}
 		rel, err := filepath.Rel(dest, path)
 		if err != nil {
 			return err
@@ -931,7 +955,16 @@ func createImpliedDirectories(dest string, hdr *tar.Header, options *TarOptions)
 	// Not the root directory, ensure that the parent directory exists
 	if !strings.HasSuffix(hdr.Name, string(os.PathSeparator)) {
 		parent := filepath.Dir(hdr.Name)
-		parentPath := filepath.Join(dest, parent)
+		var parentPath string
+		if options.ConfineSymlinksToRoot {
+			var err error
+			parentPath, err = secureJoinScope(dest, parent)
+			if err != nil {
+				return err
+			}
+		} else {
+			parentPath = filepath.Join(dest, parent)
+		}
 		if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
 			// RootPair() is confined inside this loop as most cases will not require a call, so we can spend some
 			// unneeded function calls in the uncommon case to encapsulate logic -- implied directories are a niche

--- a/chrootarchive/archive_windows.go
+++ b/chrootarchive/archive_windows.go
@@ -29,6 +29,15 @@ func invokeUnpack(decompressedArchive io.ReadCloser, dest string, options *archi
 	// Windows is different to Linux here because Windows does not support
 	// chroot. Hence there is no point sandboxing a chrooted process to
 	// do the unpack. We call inline instead within the daemon process.
+	//
+	// Because there is no chroot to contain the extraction, confine symlink
+	// resolution to the extraction root so that an "escaping" symlink in the
+	// archive cannot be used to break out (moby/moby#47107). This mirrors the
+	// containment the Linux path gets from chroot.
+	if options == nil {
+		options = &archive.TarOptions{}
+	}
+	options.ConfineSymlinksToRoot = true
 	return archive.Unpack(decompressedArchive, addLongPathPrefix(dest), options)
 }
 

--- a/chrootarchive/archive_windows_test.go
+++ b/chrootarchive/archive_windows_test.go
@@ -1,0 +1,69 @@
+//go:build windows
+
+package chrootarchive
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// TestUntarSymlinkScopeConfine is a regression test for moby/moby#47107
+// (TestBuildSymlinkBreakout) on Windows. Windows has no chroot, so chrootarchive
+// unpacks inline against the real filesystem. A symlink whose target escapes the
+// extraction root must be scope-confined rather than rejected: the symlink is
+// created (matching the Linux chroot behaviour that lets the build succeed) and
+// a file written *through* it is contained at the extraction root instead of
+// breaking out to the host.
+func TestUntarSymlinkScopeConfine(t *testing.T) {
+	const contained = "contained"
+
+	buf := &bytes.Buffer{}
+	tw := tar.NewWriter(buf)
+	// An escaping symlink: enough ".." to climb above any extraction root.
+	assert.NilError(t, tw.WriteHeader(&tar.Header{
+		Name:     "symlink2",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "/../../../../../../../../../../../../../../",
+		Mode:     0o755,
+	}))
+	// A regular file written through the escaping symlink.
+	assert.NilError(t, tw.WriteHeader(&tar.Header{
+		Name:     "symlink2/file-in-escape",
+		Typeflag: tar.TypeReg,
+		Size:     int64(len(contained)),
+		Mode:     0o644,
+	}))
+	_, err := tw.Write([]byte(contained))
+	assert.NilError(t, err)
+	assert.NilError(t, tw.Close())
+
+	base := t.TempDir()
+	dest := filepath.Join(base, "dest")
+	assert.NilError(t, os.Mkdir(dest, 0o755))
+
+	// The escaping symlink must not be rejected; extraction succeeds.
+	assert.NilError(t, Untar(bytes.NewReader(buf.Bytes()), dest, nil))
+
+	// The symlink itself was created inside dest.
+	fi, err := os.Lstat(filepath.Join(dest, "symlink2"))
+	assert.NilError(t, err)
+	assert.Check(t, fi.Mode()&os.ModeSymlink != 0, "symlink2 should be a symlink")
+
+	// The file written through the escaping symlink is contained at the root of
+	// dest (the Windows analogue of the Linux chroot root), not escaped.
+	b, err := os.ReadFile(filepath.Join(dest, "file-in-escape"))
+	assert.NilError(t, err)
+	assert.Equal(t, string(b), contained)
+
+	// Nothing escaped above dest.
+	_, err = os.Lstat(filepath.Join(base, "file-in-escape"))
+	assert.Check(t, is.ErrorIs(err, os.ErrNotExist))
+	_, err = os.Lstat(filepath.Join(filepath.VolumeName(dest)+`\`, "file-in-escape"))
+	assert.Check(t, is.ErrorIs(err, os.ErrNotExist))
+}

--- a/securejoin.go
+++ b/securejoin.go
@@ -1,0 +1,115 @@
+package archive
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// secureJoinScope joins unsafePath onto root, resolving any symlink components
+// that already exist on disk but clamping every traversal (via ".." or via a
+// symlink target) so the result can never escape root.
+//
+// It is used when TarOptions.ConfineSymlinksToRoot is set — most notably by the
+// chrootarchive subpackage on Windows, where there is no chroot to contain the
+// extraction (see moby/moby#47107). On Linux, chrootarchive performs an actual
+// chroot, so an escaping symlink is contained by the kernel; on Windows the
+// unpack runs inline against the real filesystem, and secureJoinScope provides
+// the equivalent containment: a following entry written *through* an escaping
+// symlink resolves back inside root instead of breaking out.
+//
+// The traversal mirrors github.com/containerd/continuity/fs.RootPath:
+// non-existent trailing components are accepted verbatim (so it can be used for
+// paths being created), symlink targets are resolved relative to root, and any
+// ".." that would climb above root is clamped to root.
+func secureJoinScope(root, unsafePath string) (string, error) {
+	unsafePath = filepath.FromSlash(unsafePath)
+
+	// resolved is always a cleaned, root-relative path that stays within root.
+	var resolved string
+	linksWalked := 0
+
+	for unsafePath != "" {
+		part, rest := splitFirstComponent(unsafePath)
+		unsafePath = rest
+
+		switch part {
+		case "", ".":
+			continue
+		case "..":
+			resolved = parentOf(resolved)
+			continue
+		}
+
+		next := filepath.Join(resolved, part)
+		full := filepath.Join(root, next)
+
+		fi, err := os.Lstat(full)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Nothing exists here yet; accept the component verbatim. This
+				// is where new files/dirs/symlinks get created.
+				resolved = next
+				continue
+			}
+			return "", err
+		}
+
+		if fi.Mode()&os.ModeSymlink == 0 {
+			resolved = next
+			continue
+		}
+
+		linksWalked++
+		if linksWalked > 255 {
+			return "", errors.New("securejoin: too many symbolic links")
+		}
+
+		dest, err := os.Readlink(full)
+		if err != nil {
+			return "", err
+		}
+		dest = filepath.FromSlash(dest)
+
+		if filepath.IsAbs(dest) || strings.HasPrefix(dest, string(filepath.Separator)) {
+			// Absolute target: reinterpret relative to root (the container
+			// root), dropping any volume name and leading separators.
+			resolved = ""
+			dest = strings.TrimPrefix(dest, filepath.VolumeName(dest))
+			dest = strings.TrimLeft(dest, `\/`)
+		} else {
+			// Relative target resolves from the symlink's parent directory.
+			resolved = parentOf(resolved)
+		}
+
+		if unsafePath == "" {
+			unsafePath = dest
+		} else if dest != "" {
+			unsafePath = dest + string(filepath.Separator) + unsafePath
+		}
+	}
+
+	return filepath.Join(root, resolved), nil
+}
+
+// splitFirstComponent splits p into its first path component and the remainder.
+func splitFirstComponent(p string) (first, rest string) {
+	if i := strings.IndexRune(p, filepath.Separator); i >= 0 {
+		return p[:i], p[i+1:]
+	}
+	return p, ""
+}
+
+// parentOf returns the parent of a cleaned, root-relative path, never ascending
+// above the root (represented by the empty string).
+func parentOf(p string) string {
+	if p == "" {
+		return ""
+	}
+	parent := filepath.Dir(p)
+	if parent == "." || parent == string(filepath.Separator) {
+		return ""
+	}
+	return parent
+}


### PR DESCRIPTION
## Summary

Windows has no `chroot`, so `chrootarchive` unpacks inline against the real filesystem (see `chrootarchive/archive_windows.go`). As a result, an archive symlink whose target escapes the extraction root is **rejected outright** by the `strings.HasPrefix(targetPath, extractDir)` check in `createTarFile`. That breaks `ADD <tar> /` style builds on Windows that Linux handles fine, because on Linux the same unpack runs inside a chroot that simply *contains* the escaping symlink.

This is the BuildKit/Windows-containers manifestation of moby/moby#47107 (`TestBuildSymlinkBreakout`, currently `skip.If(UsingSnapshotter, ...)`).

### Approach

Add an opt-in `TarOptions.ConfineSymlinksToRoot` flag:

- Set **only** by `chrootarchive`'s Windows `invokeUnpack`. It scope-confines symlink resolution to the extraction root via a new `secureJoinScope` helper (traversal semantics ported from `containerd/continuity` `fs.RootPath`): an escaping symlink is **created** rather than rejected, and any entry written *through* it resolves back inside the root instead of breaking out — the Windows analogue of the containment the Linux path gets from chroot.
- Plain `archive.Unpack`/`Untar` are **unchanged**: without the flag they still reject escaping symlinks, so the existing `TestUntarInvalidSymlink` / `TestApplyLayerInvalidSymlink` breakout guarantees are fully preserved.

### Tests

- New `chrootarchive/archive_windows_test.go: TestUntarSymlinkScopeConfine` — an escaping symlink (`/../../..` chain) plus a file written through it: asserts the unpack **succeeds**, the symlink is created, the file is **contained** at the extraction root, and nothing escapes above it.
- All existing breakout tests (`TestUntarInvalidSymlink`, `TestUntarInvalidHardlink`, `TestApplyLayerInvalid*`, `TestUntarHardlinkToSymlink`) continue to pass on Windows.

Validated end-to-end on a Windows containerd/BuildKit worker: `ADD symlink.tar /` (escaping symlink) that previously failed with `invalid symlink ...` now builds successfully with the file contained.

## Release notes

```
Confine symlink resolution to the extraction root when unpacking archives on Windows, so archives containing root-escaping symlinks extract with the same containment as the Linux chroot path.
```
