### PR TITLE
improve handling of local vs POSIX paths

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -925,13 +925,9 @@ loop:
 // not already exist. This is possible as the tar format supports 'implicit' directories, where their existence is
 // defined by the paths of files in the tar, but there are no header entries for the directories themselves, and thus
 // we most both create them and choose metadata like permissions.
-//
-// The caller should have performed filepath.Clean(hdr.Name), so hdr.Name will now be in the filepath format for the OS
-// on which the daemon is running. This precondition is required because this function assumes a OS-specific path
-// separator when checking that a path is not the root.
 func createImpliedDirectories(dest string, hdr *tar.Header, options *TarOptions) error {
-	// Not the root directory, ensure that the parent directory exists
-	if !strings.HasSuffix(hdr.Name, string(os.PathSeparator)) {
+	// For non-directory entries, ensure that the parent directory exists.
+	if hdr.Typeflag != tar.TypeDir {
 		parent := filepath.Dir(hdr.Name)
 		parentPath := filepath.Join(dest, parent)
 		if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {

--- a/archive.go
+++ b/archive.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -925,11 +926,14 @@ loop:
 // not already exist. This is possible as the tar format supports 'implicit' directories, where their existence is
 // defined by the paths of files in the tar, but there are no header entries for the directories themselves, and thus
 // we most both create them and choose metadata like permissions.
+//
+// hdr.Name is a tar header path, not a host filesystem path, and therefore uses
+// POSIX ('/') path semantics regardless of the operating system. The caller
+// must pass a normalized tar header path.
 func createImpliedDirectories(dest string, hdr *tar.Header, options *TarOptions) error {
 	// For non-directory entries, ensure that the parent directory exists.
 	if hdr.Typeflag != tar.TypeDir {
-		parent := filepath.Dir(hdr.Name)
-		parentPath := filepath.Join(dest, parent)
+		parentPath := filepath.Join(dest, filepath.FromSlash(path.Dir(hdr.Name)))
 		if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
 			// RootPair() is confined inside this loop as most cases will not require a call, so we can spend some
 			// unneeded function calls in the uncommon case to encapsulate logic -- implied directories are a niche

--- a/archive.go
+++ b/archive.go
@@ -345,7 +345,7 @@ func (ta *tarAppender) addTarFile(srcPath, archivePath string) error {
 	// handle re-mapping container ID mappings back to host ID mappings before
 	// writing tar headers/files. We skip whiteout files because they were written
 	// by the kernel and already have proper ownership relative to the host
-	if !isOverlayWhiteout && !strings.HasPrefix(filepath.Base(hdr.Name), WhiteoutPrefix) && !ta.IdentityMapping.Empty() {
+	if !isOverlayWhiteout && !strings.HasPrefix(path.Base(hdr.Name), WhiteoutPrefix) && !ta.IdentityMapping.Empty() {
 		uid, gid, err := getFileUIDGID(fi.Sys())
 		if err != nil {
 			return err
@@ -482,13 +482,18 @@ func createTarFile(dstPath, extractDir string, hdr *tar.Header, reader io.Reader
 		}
 
 	case tar.TypeSymlink:
-		// 	path 				-> hdr.Linkname = targetPath
-		// e.g. /extractDir/path/to/symlink 	-> ../2/file	= /extractDir/path/2/file
-		targetPath := filepath.Join(filepath.Dir(dstPath), hdr.Linkname) // #nosec G305 -- The target path is checked for path traversal.
+		// dstPath is the symlink path being created.
+		// hdr.Linkname is the symlink target as stored in the tar header.
+		// Example:
+		//   /extractDir/path/to/symlink -> ../2/file
+		// resolves for validation to:
+		//   /extractDir/path/2/file
+		targetPath := filepath.Join(filepath.Dir(dstPath), filepath.FromSlash(hdr.Linkname)) // #nosec G305 -- The target path is checked for path traversal.
 
 		// the reason we don't need to check symlinks in the path (with FollowSymlinkInScope) is because
 		// that symlink would first have to be created, which would be caught earlier, at this very check:
-		if !strings.HasPrefix(targetPath, extractDir) {
+		rel, err := filepath.Rel(extractDir, targetPath)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 			return breakoutError(fmt.Errorf("invalid symlink %q -> %q", dstPath, hdr.Linkname))
 		}
 		if err := os.Symlink(hdr.Linkname, dstPath); err != nil {
@@ -551,7 +556,7 @@ func createTarFile(dstPath, extractDir string, hdr *tar.Header, reader io.Reader
 
 	// chtimes doesn't support a NOFOLLOW flag atm
 	if hdr.Typeflag == tar.TypeLink {
-		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
+		if fi, err := os.Lstat(filepath.FromSlash(hdr.Linkname)); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
 			if err := chtimes(dstPath, aTime, mTime); err != nil {
 				return err
 			}
@@ -795,7 +800,8 @@ func (t *Tarballer) Do() {
 				relFilePath = strings.Replace(relFilePath, include, replacement, 1)
 			}
 
-			if err := ta.addTarFile(filePath, relFilePath); err != nil {
+			archivePath := filepath.ToSlash(relFilePath)
+			if err := ta.addTarFile(filePath, archivePath); err != nil {
 				log.G(context.TODO()).Errorf("Can't add file %s to tar: %s", filePath, err)
 				// if pipe is broken, stop writing tar stream to it
 				if errors.Is(err, io.ErrClosedPipe) {

--- a/archive.go
+++ b/archive.go
@@ -833,9 +833,8 @@ loop:
 		}
 
 		// Normalize name, for safety and for a simple is-root check
-		// This keeps "../" as-is, but normalizes "/../" to "/". Or Windows:
-		// This keeps "..\" as-is, but normalizes "\..\" to "\".
-		hdr.Name = filepath.Clean(hdr.Name)
+		// This keeps "../" as-is, but normalizes "/../" to "/".
+		hdr.Name = path.Clean(hdr.Name)
 
 		for _, exclude := range options.ExcludePatterns {
 			if strings.HasPrefix(hdr.Name, exclude) {
@@ -850,7 +849,7 @@ loop:
 		}
 
 		// #nosec G305 -- The joined path is checked for path traversal.
-		dstPath := filepath.Join(dest, hdr.Name)
+		dstPath := filepath.Join(dest, filepath.FromSlash(hdr.Name))
 		rel, err := filepath.Rel(dest, dstPath)
 		if err != nil {
 			return err
@@ -914,7 +913,7 @@ loop:
 
 	for _, hdr := range dirs {
 		// #nosec G305 -- The header was checked for path traversal before it was appended to the dirs slice.
-		dstPath := filepath.Join(dest, hdr.Name)
+		dstPath := filepath.Join(dest, filepath.FromSlash(hdr.Name))
 		if err := chtimes(dstPath, boundTime(latestTime(hdr.AccessTime, hdr.ModTime)), boundTime(hdr.ModTime)); err != nil {
 			return err
 		}

--- a/diff.go
+++ b/diff.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -49,7 +50,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 		size += hdr.Size
 
 		// Normalize name, for safety and for a simple is-root check
-		hdr.Name = filepath.Clean(hdr.Name)
+		hdr.Name = path.Clean(hdr.Name)
 
 		// Windows does not support filenames with colons in them. Ignore
 		// these files. This is not a problem though (although it might
@@ -84,7 +85,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			// We don't want this directory, but we need the files in them so that
 			// such hardlinks can be resolved.
 			if strings.HasPrefix(hdr.Name, WhiteoutLinkDir) && hdr.Typeflag == tar.TypeReg {
-				basename := filepath.Base(hdr.Name)
+				basename := path.Base(hdr.Name)
 				aufsHardlinks[basename] = hdr
 				if aufsTempdir == "" {
 					if aufsTempdir, err = os.MkdirTemp(dest, "dockerplnk"); err != nil {
@@ -102,7 +103,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			}
 		}
 		// #nosec G305 -- The joined path is guarded against path traversal.
-		dstPath := filepath.Join(dest, hdr.Name)
+		dstPath := filepath.Join(dest, filepath.FromSlash(hdr.Name))
 		rel, err := filepath.Rel(dest, dstPath)
 		if err != nil {
 			return 0, err
@@ -197,7 +198,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 
 	for _, hdr := range dirs {
 		// #nosec G305 -- The header was checked for path traversal before it was appended to the dirs slice.
-		dstPath := filepath.Join(dest, hdr.Name)
+		dstPath := filepath.Join(dest, filepath.FromSlash(hdr.Name))
 		if err := chtimes(dstPath, hdr.AccessTime, hdr.ModTime); err != nil {
 			return 0, err
 		}

--- a/diff.go
+++ b/diff.go
@@ -165,8 +165,8 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 
 			// Hard links into /.wh..wh.plnk don't work, as we don't extract that directory, so
 			// we manually retarget these into the temporary files we extracted them into
-			if hdr.Typeflag == tar.TypeLink && strings.HasPrefix(filepath.Clean(hdr.Linkname), WhiteoutLinkDir) {
-				linkBasename := filepath.Base(hdr.Linkname)
+			if hdr.Typeflag == tar.TypeLink && strings.HasPrefix(path.Clean(hdr.Linkname), WhiteoutLinkDir) {
+				linkBasename := path.Base(hdr.Linkname)
 				srcHdr = aufsHardlinks[linkBasename]
 				if srcHdr == nil {
 					return 0, errors.New("invalid aufs hardlink")


### PR DESCRIPTION
### ExportChanges: use POSIX / Unix conventions for Tar operations

The Change.Path field holds a local path, but it was used to set
the Tar.Name field.

Convert the path to a POSIX / Unix path before setting. Also explicitly
convert the archive-path to a POSIX path when calling addTarFile, and
explicitly strip a leading `/` (if present), instead of the first
character.


### createImpliedDirectories: fix directory detection and path handling

The code used os.PathSeparator to detect if the Tar-header was not for
a directory, but Tar headers use POSIX (forward-slashes), so this would
fail on Windows.

While updating, also update the parent path handling to use the right
conventions (forward-slashes) before constructing a local path.


### RebaseArchiveEntries: use POSIX / Unix paths

This is mostly defense-in-depth; RebaseArchiveEntries is manipulating
the Tar headers, which use POSIX / Unix paths; convert the given paths
on the way in.
