### PR TITLE
tarAppender.addTarFile: normalize archivePath to POSIX

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -296,6 +296,7 @@ func canonicalTarName(name string, isDir bool) string {
 
 // addTarFile adds to the tar archive a file from `srcPath` as `name`
 func (ta *tarAppender) addTarFile(srcPath, archivePath string) error {
+	archivePath = filepath.ToSlash(archivePath)
 	fi, err := os.Lstat(srcPath)
 	if err != nil {
 		return err
@@ -332,7 +333,7 @@ func (ta *tarAppender) addTarFile(srcPath, archivePath string) error {
 			hdr.Linkname = oldpath
 			hdr.Size = 0 // This Must be here for the writer math to add up!
 		} else {
-			ta.SeenFiles[inode] = archivePath
+			ta.SeenFiles[inode] = hdr.Name
 		}
 	}
 


### PR DESCRIPTION
The archivePath is used as the path in the Tar archive, which uses POSIX / Unix paths.

Normalize the path as a defense in-depth (FileInfoHeader also normalizes), then use the normalized hdr.Name as source of truth to set Linkname.