### PR TITLE
RebaseArchiveEntries: use POSIX / Unix paths

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -319,7 +319,10 @@ func PrepareArchiveCopy(srcContent io.Reader, srcInfo, dstInfo CopyInfo) (dstDir
 // RebaseArchiveEntries rewrites the given srcContent archive replacing
 // an occurrence of oldBase with newBase at the beginning of entry names.
 func RebaseArchiveEntries(srcContent io.Reader, oldBase, newBase string) io.ReadCloser {
-	if oldBase == string(os.PathSeparator) {
+	oldBase = filepath.ToSlash(oldBase)
+	newBase = filepath.ToSlash(newBase)
+
+	if oldBase == "/" {
 		// If oldBase specifies the root directory, use an empty string as
 		// oldBase instead so that newBase doesn't replace the path separator
 		// that all paths will start with.

--- a/copy_test.go
+++ b/copy_test.go
@@ -1,0 +1,92 @@
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestRebaseArchiveEntriesPlatformPaths(t *testing.T) {
+	cases := []struct {
+		name         string
+		oldBase      string
+		newBase      string
+		headerName   string
+		linkName     string
+		wantName     string
+		wantLinkName string
+	}{
+		{
+			name:       "regular file",
+			oldBase:    filepath.Join("origin", "subdir"),
+			newBase:    filepath.Join("dest", "target"),
+			headerName: "origin/subdir/file",
+			wantName:   "dest/target/file",
+		},
+		{
+			name:       "regular file POSIX",
+			oldBase:    "origin/subdir",
+			newBase:    "dest/target",
+			headerName: "origin/subdir/file",
+			wantName:   "dest/target/file",
+		},
+		{
+			name:         "hardlink",
+			oldBase:      filepath.Join("origin", "subdir"),
+			newBase:      filepath.Join("dest", "target"),
+			headerName:   "origin/subdir/link",
+			linkName:     "origin/subdir/file",
+			wantName:     "dest/target/link",
+			wantLinkName: "dest/target/file",
+		},
+		{
+			name:         "hardlink POSIX",
+			oldBase:      "origin/subdir",
+			newBase:      "dest/target",
+			headerName:   "origin/subdir/link",
+			linkName:     "origin/subdir/file",
+			wantName:     "dest/target/link",
+			wantLinkName: "dest/target/file",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			tw := tar.NewWriter(&buf)
+
+			hdr := &tar.Header{
+				Name: tc.headerName,
+				Mode: 0o644,
+			}
+			if tc.linkName != "" {
+				hdr.Typeflag = tar.TypeLink
+				hdr.Linkname = tc.linkName
+			} else {
+				hdr.Typeflag = tar.TypeReg
+				hdr.Size = int64(len("content"))
+			}
+
+			assert.NilError(t, tw.WriteHeader(hdr))
+			if hdr.Typeflag == tar.TypeReg {
+				_, err := tw.Write([]byte("content"))
+				assert.NilError(t, err)
+			}
+			assert.NilError(t, tw.Close())
+
+			rc := RebaseArchiveEntries(&buf, tc.oldBase, tc.newBase)
+			defer rc.Close()
+
+			tr := tar.NewReader(rc)
+			got, err := tr.Next()
+			assert.NilError(t, err)
+
+			assert.Check(t, is.Equal(got.Name, tc.wantName))
+			assert.Check(t, is.Equal(got.Linkname, tc.wantLinkName))
+		})
+	}
+}


### PR DESCRIPTION
This is mostly defense-in-depth; RebaseArchiveEntries is manipulating the Tar headers, which use POSIX / Unix paths; convert the given paths on the way in.