### PR TITLE
gha: update golangci-lint to v2.12 for compatibility with go1.26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
       - name: lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.7
-          args: --print-resources-usage --timeout=10m --verbose
+          version: v2.12
+          args: --timeout=10m --verbose
 
       - name: Test
         run: go test -v -cover "-coverprofile=coverage.txt" -covermode=atomic ./...


### PR DESCRIPTION
Also remove deprecated flag;

    Flag --print-resources-usage has been deprecated, use --verbose instead
