### PR TITLE
golangci-lint: enable gosec linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ issues:
 linters:
   enable:
     - errorlint
+    - gosec
     - unconvert
     - unparam
   exclusions:
@@ -16,7 +17,18 @@ linters:
     presets:
       - comments
       - std-error-handling
+    rules:
+      # Ignore "G204: Subprocess launched with a potential tainted input or cmd arguments"
+      - path: '(.+)_test\.go'
+        linters:
+          - gosec
+        text: 'G204: Subprocess launched'
   settings:
+    gosec:
+      excludes:
+        - G301 # Expect directory permissions to be 0750 or less
+        - G304 # Potential file inclusion via variable
+        - G306 # Expect WriteFile permissions to be 0600 or less
     staticcheck:
       # Enable all options, with some exceptions.
       # For defaults, see https://golangci-lint.run/usage/linters/#staticcheck

--- a/archive.go
+++ b/archive.go
@@ -233,7 +233,7 @@ func FileInfoHeader(name string, fi os.FileInfo, link string) (*tar.Header, erro
 	hdr.ModTime = hdr.ModTime.Truncate(time.Second)
 	hdr.AccessTime = time.Time{}
 	hdr.ChangeTime = time.Time{}
-	hdr.Mode = int64(chmodTarEntry(os.FileMode(hdr.Mode)))
+	hdr.Mode = chmodTarEntry(hdr.Mode)
 	hdr.Name = canonicalTarName(name, fi.IsDir())
 	return hdr, nil
 }
@@ -1105,7 +1105,7 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 			hdr.AccessTime = time.Time{}
 			hdr.ChangeTime = time.Time{}
 			hdr.Name = filepath.Base(dst)
-			hdr.Mode = int64(chmodTarEntry(os.FileMode(hdr.Mode)))
+			hdr.Mode = chmodTarEntry(hdr.Mode)
 
 			if err := remapIDs(archiver.IDMapping, hdr); err != nil {
 				return err

--- a/archive_linux_test.go
+++ b/archive_linux_test.go
@@ -108,7 +108,7 @@ func TestOverlayTarUntar(t *testing.T) {
 	})
 	assert.NilError(t, err)
 	archive, err := io.ReadAll(reader)
-	reader.Close()
+	assert.NilError(t, reader.Close())
 	assert.NilError(t, err)
 
 	// The archive should encode opaque directories and file whiteouts

--- a/archive_unix.go
+++ b/archive_unix.go
@@ -33,8 +33,8 @@ func getWalkRoot(srcPath string, include string) string {
 
 // chmodTarEntry is used to adjust the file permissions used in tar header based
 // on the platform the archival is done.
-func chmodTarEntry(perm os.FileMode) os.FileMode {
-	return perm // noop for unix as golang APIs provide perm bits correctly
+func chmodTarEntry(mode int64) int64 {
+	return mode // noop for unix as golang APIs provide perm bits correctly
 }
 
 func getInodeFromStat(stat any) (uint64, error) {

--- a/archive_unix_test.go
+++ b/archive_unix_test.go
@@ -46,7 +46,7 @@ func TestCanonicalTarName(t *testing.T) {
 
 func TestChmodTarEntry(t *testing.T) {
 	cases := []struct {
-		in, expected os.FileMode
+		in, expected int64
 	}{
 		{0o000, 0o000},
 		{0o777, 0o777},
@@ -56,7 +56,7 @@ func TestChmodTarEntry(t *testing.T) {
 	}
 	for _, v := range cases {
 		if out := chmodTarEntry(v.in); out != v.expected {
-			t.Fatalf("wrong chmod. expected:%v got:%v", v.expected, out)
+			t.Fatalf("wrong chmod: expected=%#o got=%#o", v.expected, out)
 		}
 	}
 }

--- a/archive_windows.go
+++ b/archive_windows.go
@@ -33,12 +33,12 @@ func getWalkRoot(srcPath string, include string) string {
 
 // chmodTarEntry is used to adjust the file permissions used in tar header based
 // on the platform the archival is done.
-func chmodTarEntry(perm os.FileMode) os.FileMode {
+func chmodTarEntry(mode int64) int64 {
 	// Remove group- and world-writable bits.
-	perm &= 0o755
+	mode &= 0o755
 
 	// Add the x bit: make everything +x on Windows
-	return perm | 0o111
+	return mode | 0o111
 }
 
 func getInodeFromStat(stat any) (uint64, error) {

--- a/archive_windows_test.go
+++ b/archive_windows_test.go
@@ -53,7 +53,7 @@ func TestCanonicalTarName(t *testing.T) {
 
 func TestChmodTarEntry(t *testing.T) {
 	cases := []struct {
-		in, expected os.FileMode
+		in, expected int64
 	}{
 		{0o000, 0o111},
 		{0o777, 0o755},
@@ -63,7 +63,7 @@ func TestChmodTarEntry(t *testing.T) {
 	}
 	for _, v := range cases {
 		if out := chmodTarEntry(v.in); out != v.expected {
-			t.Fatalf("wrong chmod. expected:%v got:%v", v.expected, out)
+			t.Fatalf("wrong chmod: expected=%#o got=%#o", v.expected, out)
 		}
 	}
 }

--- a/chrootarchive/archive_unix_nolinux.go
+++ b/chrootarchive/archive_unix_nolinux.go
@@ -119,9 +119,9 @@ func doPack(relSrc, root string, options *archive.TarOptions) (io.ReadCloser, er
 		_, _ = io.Copy(w, stdout)
 		// Cleanup once stdout pipe is closed.
 		if err = cmd.Wait(); err != nil {
-			r.CloseWithError(fmt.Errorf("%s: %w", stderr.String(), err))
+			_ = r.CloseWithError(fmt.Errorf("%s: %w", stderr.String(), err))
 		} else {
-			r.Close()
+			_ = r.Close()
 		}
 	}()
 

--- a/compression/compression.go
+++ b/compression/compression.go
@@ -217,7 +217,7 @@ func gzipDecompress(ctx context.Context, buf io.Reader) (io.ReadCloser, error) {
 
 	log.G(ctx).Debugf("Using %s to decompress", unpigzPath)
 
-	return cmdStream(exec.CommandContext(ctx, unpigzPath, "-d", "-c"), buf)
+	return cmdStream(exec.CommandContext(ctx, unpigzPath, "-d", "-c"), buf) // #nosec G204 -- Subprocess launched with variable
 }
 
 // cmdStream executes a command, and returns its stdout as a stream.

--- a/dev_unix.go
+++ b/dev_unix.go
@@ -5,5 +5,5 @@ package archive
 import "golang.org/x/sys/unix"
 
 func mknod(path string, mode uint32, dev uint64) error {
-	return unix.Mknod(path, mode, int(dev))
+	return unix.Mknod(path, mode, int(dev)) // #nosec G115 -- Required conversion for the platform-specific Mknod API.
 }

--- a/diff.go
+++ b/diff.go
@@ -129,7 +129,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 						return nil
 					}
 					if _, exists := unpackedPaths[path]; !exists {
-						return os.RemoveAll(path)
+						return os.RemoveAll(path) // #nosec G122 -- FIXME: consider root-scoped APIs (e.g. os.Root) to prevent symlink TOCTOU traversal
 					}
 					return nil
 				})

--- a/tarheader/tarheader_unix.go
+++ b/tarheader/tarheader_unix.go
@@ -36,10 +36,11 @@ func sysStat(fi os.FileInfo, hdr *tar.Header) error {
 	hdr.Uid = int(s.Uid)
 	hdr.Gid = int(s.Gid)
 
-	if s.Mode&unix.S_IFBLK != 0 ||
-		s.Mode&unix.S_IFCHR != 0 {
-		hdr.Devmajor = int64(unix.Major(uint64(s.Rdev))) //nolint: unconvert
-		hdr.Devminor = int64(unix.Minor(uint64(s.Rdev))) //nolint: unconvert
+	if s.Mode&unix.S_IFBLK != 0 || s.Mode&unix.S_IFCHR != 0 {
+		// #nosec G115 -- Rdev type varies by platform.
+		rdev := uint64(s.Rdev) //nolint:unconvert // Rdev type varies by platform.
+		hdr.Devmajor = int64(unix.Major(rdev))
+		hdr.Devminor = int64(unix.Minor(rdev))
 	}
 
 	return nil

--- a/utils_test.go
+++ b/utils_test.go
@@ -173,7 +173,7 @@ func testBreakout(untarFn string, tmpdir string, headers []*tar.Header) error {
 			// skip file if error
 			return nil
 		}
-		b, err := os.ReadFile(path)
+		b, err := os.ReadFile(path) // #nosec G122 -- TOCTOU / filesystem traversal safe to ignore for tests.
 		if err != nil {
 			// Houston, we have a problem. Aborting (space)walk.
 			return err


### PR DESCRIPTION
- [x] stacked on https://github.com/moby/go-archive/pull/46
- [x] stacked on https://github.com/moby/go-archive/pull/45