### PR TITLE
archive: cache parent directory fd during tar extraction

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -440,7 +440,10 @@ func (ta *tarAppender) addTarFile(srcPath, archivePath string) error {
 // createTarFile extracts a single tar entry into the given root. dstPath is the
 // root-relative path of the entry being extracted, in native (host-separator)
 // form so it can be passed directly to os.Root methods and fsRootPath.
-func createTarFile(root *os.Root, dstPath string, hdr *tar.Header, reader io.Reader, opts *TarOptions) error {
+//
+// dc caches the last-used parent directory fd to avoid repeated path walks
+// for consecutive entries in the same directory.
+func createTarFile(dc *dirCache, root *os.Root, dstPath string, hdr *tar.Header, reader io.Reader, opts *TarOptions) error {
 	var (
 		Lchown                     = true
 		inUserns, bestEffortXattrs bool
@@ -466,8 +469,12 @@ func createTarFile(root *os.Root, dstPath string, hdr *tar.Header, reader io.Rea
 		// os.Root.Mkdir only accepts the nine least-significant permission
 		// bits; special bits (setuid, setgid, sticky) are applied afterward
 		// by handleLChmod via root.Chmod.
-		if fi, err := root.Lstat(dstPath); err != nil || !fi.IsDir() {
-			if err := root.Mkdir(dstPath, hdrInfo.Mode()&0o777); err != nil {
+		isDir, err := dc.isExistingDir(root, dstPath)
+		if err != nil {
+			return err
+		}
+		if !isDir {
+			if err := dc.mkdir(root, dstPath, hdrInfo.Mode()&0o777); err != nil {
 				return err
 			}
 		}
@@ -479,7 +486,7 @@ func createTarFile(root *os.Root, dstPath string, hdr *tar.Header, reader io.Rea
 		// bits; special bits are applied afterward by handleLChmod.
 		// We use sequential file access to avoid depleting the standby list
 		// on Windows (go1.26). On Linux, this equates to a regular os.OpenFile.
-		file, err := root.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|windows_O_FILE_FLAG_SEQUENTIAL_SCAN, hdrInfo.Mode()&0o777)
+		file, err := dc.openFile(root, dstPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|windows_O_FILE_FLAG_SEQUENTIAL_SCAN, hdrInfo.Mode()&0o777)
 		if err != nil {
 			return err
 		}
@@ -548,7 +555,7 @@ func createTarFile(root *os.Root, dstPath string, hdr *tar.Header, reader io.Rea
 		if chownOpts == nil {
 			chownOpts = &ChownOpts{UID: hdr.Uid, GID: hdr.Gid}
 		}
-		if err := root.Lchown(dstPath, chownOpts.UID, chownOpts.GID); err != nil {
+		if err := dc.lchown(root, dstPath, chownOpts.UID, chownOpts.GID); err != nil {
 			var msg string
 			if inUserns && errors.Is(err, syscall.EINVAL) {
 				msg = " (try increasing the number of subordinate IDs in /etc/subuid and /etc/subgid)"
@@ -591,7 +598,7 @@ func createTarFile(root *os.Root, dstPath string, hdr *tar.Header, reader io.Rea
 
 	// There is no LChmod, so ignore mode for symlink. Also, this
 	// must happen after chown, as that can modify the file mode
-	if err := handleLChmod(root, dstPath, hdr, hdrInfo); err != nil {
+	if err := handleLChmod(dc, root, dstPath, hdr, hdrInfo); err != nil {
 		return err
 	}
 
@@ -601,20 +608,20 @@ func createTarFile(root *os.Root, dstPath string, hdr *tar.Header, reader io.Rea
 	switch hdr.Typeflag {
 	case tar.TypeSymlink:
 		// Apply timestamps to the symlink itself (AT_SYMLINK_NOFOLLOW).
-		if err := lchtimes(root, dstPath, aTime, mTime); err != nil {
+		if err := dc.lchtimes(root, dstPath, aTime, mTime); err != nil {
 			return err
 		}
 	case tar.TypeLink:
 		// Follow the hardlink only when its target is not itself a symlink.
 		fi, err := root.Lstat(filepath.FromSlash(path.Clean(hdr.Linkname)))
 		if err == nil && fi.Mode()&os.ModeSymlink == 0 {
-			if err := root.Chtimes(dstPath, aTime, mTime); err != nil {
+			if err := dc.chtimes(root, dstPath, aTime, mTime); err != nil {
 				return err
 			}
 		}
 	default:
 		// All other file types follow symlinks.
-		if err := root.Chtimes(dstPath, aTime, mTime); err != nil {
+		if err := dc.chtimes(root, dstPath, aTime, mTime); err != nil {
 			return err
 		}
 	}
@@ -881,6 +888,11 @@ func Unpack(decompressedArchive io.Reader, dest string, options *TarOptions) err
 
 	tr := tar.NewReader(decompressedArchive)
 
+	// dc caches the last-opened parent directory fd so that consecutive
+	// entries in the same directory avoid re-walking the full path.
+	var dc dirCache
+	defer dc.close()
+
 	var dirs []unpackedDir
 	whiteoutConverter := getWhiteoutConverter(options.WhiteoutFormat)
 
@@ -981,7 +993,7 @@ loop:
 			}
 		}
 
-		if err := createTarFile(root, dstPath, hdr, tr, options); err != nil {
+		if err := createTarFile(&dc, root, dstPath, hdr, tr, options); err != nil {
 			return err
 		}
 

--- a/archive.go
+++ b/archive.go
@@ -607,9 +607,13 @@ func createTarFile(dc *dirCache, root *os.Root, dstPath string, hdr *tar.Header,
 
 	switch hdr.Typeflag {
 	case tar.TypeSymlink:
-		// Apply timestamps to the symlink itself (AT_SYMLINK_NOFOLLOW).
-		if err := dc.lchtimes(dstPath, aTime, mTime); err != nil {
-			return err
+		// Apply timestamps to the symlink itself.
+		parent, err := dc.openDir(filepath.Dir(dstPath))
+		if err != nil {
+			return &os.PathError{Op: "lchtimes", Path: dstPath, Err: err}
+		}
+		if err := lchtimesAt(parent, filepath.Base(dstPath), aTime, mTime); err != nil {
+			return &os.PathError{Op: "lchtimes", Path: dstPath, Err: err}
 		}
 	case tar.TypeLink:
 		// Follow the hardlink only when its target is not itself a symlink.

--- a/archive.go
+++ b/archive.go
@@ -469,12 +469,12 @@ func createTarFile(dc *dirCache, root *os.Root, dstPath string, hdr *tar.Header,
 		// os.Root.Mkdir only accepts the nine least-significant permission
 		// bits; special bits (setuid, setgid, sticky) are applied afterward
 		// by handleLChmod via root.Chmod.
-		isDir, err := dc.isExistingDir(root, dstPath)
+		isDir, err := dc.isExistingDir(dstPath)
 		if err != nil {
 			return err
 		}
 		if !isDir {
-			if err := dc.mkdir(root, dstPath, hdrInfo.Mode()&0o777); err != nil {
+			if err := dc.mkdir(dstPath, hdrInfo.Mode()&0o777); err != nil {
 				return err
 			}
 		}
@@ -486,7 +486,7 @@ func createTarFile(dc *dirCache, root *os.Root, dstPath string, hdr *tar.Header,
 		// bits; special bits are applied afterward by handleLChmod.
 		// We use sequential file access to avoid depleting the standby list
 		// on Windows (go1.26). On Linux, this equates to a regular os.OpenFile.
-		file, err := dc.openFile(root, dstPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|windows_O_FILE_FLAG_SEQUENTIAL_SCAN, hdrInfo.Mode()&0o777)
+		file, err := dc.openFile(dstPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|windows_O_FILE_FLAG_SEQUENTIAL_SCAN, hdrInfo.Mode()&0o777)
 		if err != nil {
 			return err
 		}
@@ -555,7 +555,7 @@ func createTarFile(dc *dirCache, root *os.Root, dstPath string, hdr *tar.Header,
 		if chownOpts == nil {
 			chownOpts = &ChownOpts{UID: hdr.Uid, GID: hdr.Gid}
 		}
-		if err := dc.lchown(root, dstPath, chownOpts.UID, chownOpts.GID); err != nil {
+		if err := dc.lchown(dstPath, chownOpts.UID, chownOpts.GID); err != nil {
 			var msg string
 			if inUserns && errors.Is(err, syscall.EINVAL) {
 				msg = " (try increasing the number of subordinate IDs in /etc/subuid and /etc/subgid)"
@@ -608,20 +608,20 @@ func createTarFile(dc *dirCache, root *os.Root, dstPath string, hdr *tar.Header,
 	switch hdr.Typeflag {
 	case tar.TypeSymlink:
 		// Apply timestamps to the symlink itself (AT_SYMLINK_NOFOLLOW).
-		if err := dc.lchtimes(root, dstPath, aTime, mTime); err != nil {
+		if err := dc.lchtimes(dstPath, aTime, mTime); err != nil {
 			return err
 		}
 	case tar.TypeLink:
 		// Follow the hardlink only when its target is not itself a symlink.
 		fi, err := root.Lstat(filepath.FromSlash(path.Clean(hdr.Linkname)))
 		if err == nil && fi.Mode()&os.ModeSymlink == 0 {
-			if err := dc.chtimes(root, dstPath, aTime, mTime); err != nil {
+			if err := dc.chtimes(dstPath, aTime, mTime); err != nil {
 				return err
 			}
 		}
 	default:
 		// All other file types follow symlinks.
-		if err := dc.chtimes(root, dstPath, aTime, mTime); err != nil {
+		if err := dc.chtimes(dstPath, aTime, mTime); err != nil {
 			return err
 		}
 	}
@@ -890,7 +890,7 @@ func Unpack(decompressedArchive io.Reader, dest string, options *TarOptions) err
 
 	// dc caches the last-opened parent directory fd so that consecutive
 	// entries in the same directory avoid re-walking the full path.
-	var dc dirCache
+	dc := newDirCache(root)
 	defer dc.close()
 
 	var dirs []unpackedDir
@@ -993,7 +993,7 @@ loop:
 			}
 		}
 
-		if err := createTarFile(&dc, root, dstPath, hdr, tr, options); err != nil {
+		if err := createTarFile(dc, root, dstPath, hdr, tr, options); err != nil {
 			return err
 		}
 

--- a/archive_test.go
+++ b/archive_test.go
@@ -579,7 +579,8 @@ func TestTypeXGlobalHeaderDoesNotFail(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer root.Close()
-	err = createTarFile(root, "pax_global_header", &hdr, nil, nil)
+	var dc dirCache
+	err = createTarFile(&dc, root, "pax_global_header", &hdr, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -623,7 +624,8 @@ func TestCreateTarFileSymlinkPreservesLinkname(t *testing.T) {
 				Linkname: tc.linkname,
 			}
 
-			err = createTarFile(root, hdr.Name, &hdr, nil, &TarOptions{
+			var dc dirCache
+			err = createTarFile(&dc, root, hdr.Name, &hdr, nil, &TarOptions{
 				NoLchown: true,
 			})
 			if err != nil {

--- a/archive_test.go
+++ b/archive_test.go
@@ -579,8 +579,9 @@ func TestTypeXGlobalHeaderDoesNotFail(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer root.Close()
-	var dc dirCache
-	err = createTarFile(&dc, root, "pax_global_header", &hdr, nil, nil)
+	dc := newDirCache(root)
+	defer dc.close()
+	err = createTarFile(dc, root, "pax_global_header", &hdr, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -624,8 +625,9 @@ func TestCreateTarFileSymlinkPreservesLinkname(t *testing.T) {
 				Linkname: tc.linkname,
 			}
 
-			var dc dirCache
-			err = createTarFile(&dc, root, hdr.Name, &hdr, nil, &TarOptions{
+			dc := newDirCache(root)
+			defer dc.close()
+			err = createTarFile(dc, root, hdr.Name, &hdr, nil, &TarOptions{
 				NoLchown: true,
 			})
 			if err != nil {

--- a/archive_unix.go
+++ b/archive_unix.go
@@ -88,7 +88,10 @@ func handleTarTypeBlockCharFifo(root *os.Root, hdr *tar.Header, dstPath string) 
 // handleLChmod applies the mode from hdrInfo to dstPath within root, skipping
 // symlinks (there is no lchmod). For hardlinks, the mode is applied only when
 // the link target is itself not a symlink.
-func handleLChmod(root *os.Root, dstPath string, hdr *tar.Header, hdrInfo os.FileInfo) error {
+//
+// dc caches the last-used parent directory fd to avoid repeated path walks
+// for consecutive entries in the same directory.
+func handleLChmod(dc *dirCache, root *os.Root, dstPath string, hdr *tar.Header, hdrInfo os.FileInfo) error {
 	switch hdr.Typeflag {
 	case tar.TypeSymlink:
 		return nil
@@ -100,10 +103,10 @@ func handleLChmod(root *os.Root, dstPath string, hdr *tar.Header, hdrInfo os.Fil
 		if err != nil || fi.Mode()&os.ModeSymlink != 0 {
 			return nil
 		}
-		return chmodNoSymlink(root, dstPath, hdrInfo.Mode())
+		return dc.chmod(root, dstPath, hdrInfo.Mode())
 
 	default:
-		return chmodNoSymlink(root, dstPath, hdrInfo.Mode())
+		return dc.chmod(root, dstPath, hdrInfo.Mode())
 	}
 }
 

--- a/archive_unix.go
+++ b/archive_unix.go
@@ -103,10 +103,10 @@ func handleLChmod(dc *dirCache, root *os.Root, dstPath string, hdr *tar.Header, 
 		if err != nil || fi.Mode()&os.ModeSymlink != 0 {
 			return nil
 		}
-		return dc.chmod(root, dstPath, hdrInfo.Mode())
+		return dc.chmod(dstPath, hdrInfo.Mode())
 
 	default:
-		return dc.chmod(root, dstPath, hdrInfo.Mode())
+		return dc.chmod(dstPath, hdrInfo.Mode())
 	}
 }
 

--- a/archive_unix.go
+++ b/archive_unix.go
@@ -113,7 +113,7 @@ func handleLChmod(dc *dirCache, root *os.Root, dstPath string, hdr *tar.Header, 
 // chmodNoSymlink applies mode to a non-symlink entry.
 //
 // Callers must have already excluded symlink entries.
-func chmodNoSymlink(root *os.Root, name string, mode os.FileMode) error {
+func chmodNoSymlink(root *os.Root, name string, mode os.FileMode) error { //nolint:unused
 	parent, err := root.OpenFile(filepath.Dir(name), os.O_RDONLY, 0)
 	if err != nil {
 		return err

--- a/archive_windows.go
+++ b/archive_windows.go
@@ -53,7 +53,7 @@ func handleTarTypeBlockCharFifo(root *os.Root, hdr *tar.Header, path string) err
 }
 
 // handleLChmod is a no-op on Windows because chmod is not supported.
-func handleLChmod(root *os.Root, path string, hdr *tar.Header, hdrInfo os.FileInfo) error {
+func handleLChmod(dc *dirCache, root *os.Root, path string, hdr *tar.Header, hdrInfo os.FileInfo) error {
 	return nil
 }
 

--- a/diff.go
+++ b/diff.go
@@ -28,6 +28,11 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 
 	tr := tar.NewReader(layer)
 
+	// dc caches the last-opened parent directory fd so that consecutive
+	// entries in the same directory avoid re-walking the full path.
+	var dc dirCache
+	defer dc.close()
+
 	var dirs []unpackedDir
 	// unpackedPaths tracks root-relative paths already written in this layer
 	// so that the AUFS opaque-whiteout walk knows which paths to preserve.
@@ -95,7 +100,9 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				if err != nil {
 					return 0, err
 				}
-				cerr := createTarFile(aufsRoot, basename, hdr, tr, options)
+				var aufsDC dirCache
+				cerr := createTarFile(&aufsDC, aufsRoot, basename, hdr, tr, options)
+				aufsDC.close()
 				_ = aufsRoot.Close()
 				if cerr != nil {
 					return 0, cerr
@@ -197,7 +204,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				return 0, err
 			}
 
-			if err := createTarFile(root, dstPath, srcHdr, srcData, options); err != nil {
+			if err := createTarFile(&dc, root, dstPath, srcHdr, srcData, options); err != nil {
 				return 0, err
 			}
 

--- a/diff.go
+++ b/diff.go
@@ -30,7 +30,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 
 	// dc caches the last-opened parent directory fd so that consecutive
 	// entries in the same directory avoid re-walking the full path.
-	var dc dirCache
+	dc := newDirCache(root)
 	defer dc.close()
 
 	var dirs []unpackedDir
@@ -100,8 +100,8 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				if err != nil {
 					return 0, err
 				}
-				var aufsDC dirCache
-				cerr := createTarFile(&aufsDC, aufsRoot, basename, hdr, tr, options)
+				aufsDC := newDirCache(aufsRoot)
+				cerr := createTarFile(aufsDC, aufsRoot, basename, hdr, tr, options)
 				aufsDC.close()
 				_ = aufsRoot.Close()
 				if cerr != nil {
@@ -204,7 +204,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				return 0, err
 			}
 
-			if err := createTarFile(&dc, root, dstPath, srcHdr, srcData, options); err != nil {
+			if err := createTarFile(dc, root, dstPath, srcHdr, srcData, options); err != nil {
 				return 0, err
 			}
 

--- a/dircache_unix.go
+++ b/dircache_unix.go
@@ -1,0 +1,155 @@
+//go:build !windows
+
+package archive
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// dirCache caches an open *os.File for the most recently accessed parent
+// directory, eliminating repeated doInRoot path walks for consecutive tar
+// entries in the same directory. doInRoot opens every path component on
+// each call; with a cached parent fd, operations on the final component
+// cost a single *at(2) syscall regardless of path depth.
+//
+// The cache is keyed on both the *os.Root and the root-relative directory
+// path, so it invalidates automatically when the root changes (e.g. when a
+// separate root is used for AUFS temporary files).
+type dirCache struct {
+	root *os.Root // root under which the cached dir was opened
+	path string   // root-relative path of the cached directory
+	file *os.File // open directory fd; nil when nothing is cached
+}
+
+// close releases the cached directory fd.
+func (dc *dirCache) close() {
+	if dc.file != nil {
+		_ = dc.file.Close()
+		dc.file = nil
+		dc.path = ""
+		dc.root = nil
+	}
+}
+
+// openDir returns an open *os.File for dir within root, reusing the cached
+// fd when possible and re-opening via root.OpenFile otherwise.
+func (dc *dirCache) openDir(root *os.Root, dir string) (*os.File, error) {
+	if dc.file != nil && dc.root == root && dc.path == dir {
+		return dc.file, nil
+	}
+	if dc.file != nil {
+		_ = dc.file.Close()
+		dc.file = nil
+	}
+	// Open through root so that path resolution is bounded within the
+	// root's security boundary before we cache the raw fd.
+	f, err := root.OpenFile(dir, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	dc.file = f
+	dc.path = dir
+	dc.root = root
+	return f, nil
+}
+
+// openFile creates or truncates the file at path within root, using
+// openat(2) on the cached parent directory fd.
+func (dc *dirCache) openFile(root *os.Root, path string, flag int, perm os.FileMode) (*os.File, error) {
+	d, err := dc.openDir(root, filepath.Dir(path))
+	if err != nil {
+		return nil, err
+	}
+	fd, err := unix.Openat(int(d.Fd()), filepath.Base(path), flag|syscall.O_CLOEXEC, uint32(perm))
+	if err != nil {
+		return nil, &os.PathError{Op: "openat", Path: path, Err: err}
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}
+
+// isExistingDir reports whether path within root exists and is a directory.
+// A false return with a nil error means the path does not exist or is not a
+// directory; the caller should attempt to create it.
+func (dc *dirCache) isExistingDir(root *os.Root, path string) (bool, error) {
+	d, err := dc.openDir(root, filepath.Dir(path))
+	if err != nil {
+		return false, err
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstatat(int(d.Fd()), filepath.Base(path), &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		// Any stat error is treated as "not an existing directory"; the
+		// subsequent mkdir call will produce a real error if needed.
+		return false, nil
+	}
+	return stat.Mode&syscall.S_IFMT == syscall.S_IFDIR, nil
+}
+
+// mkdir creates a directory at path within root.
+func (dc *dirCache) mkdir(root *os.Root, path string, perm os.FileMode) error {
+	d, err := dc.openDir(root, filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	if err := unix.Mkdirat(int(d.Fd()), filepath.Base(path), uint32(perm)); err != nil {
+		return &os.PathError{Op: "mkdirat", Path: path, Err: err}
+	}
+	return nil
+}
+
+// lchown sets ownership of path without following symlinks.
+func (dc *dirCache) lchown(root *os.Root, path string, uid, gid int) error {
+	d, err := dc.openDir(root, filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	if err := unix.Fchownat(int(d.Fd()), filepath.Base(path), uid, gid, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return &os.PathError{Op: "fchownat", Path: path, Err: err}
+	}
+	return nil
+}
+
+// chmod sets the permission bits of path. It follows symlinks (i.e. acts on
+// the target); callers must not invoke this for TypeSymlink entries.
+func (dc *dirCache) chmod(root *os.Root, path string, mode os.FileMode) error {
+	d, err := dc.openDir(root, filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	if err := unix.Fchmodat(int(d.Fd()), filepath.Base(path), fileModeToPerm(mode), 0); err != nil {
+		return &os.PathError{Op: "fchmodat", Path: path, Err: err}
+	}
+	return nil
+}
+
+// chtimes sets access and modification times of path, following symlinks.
+// Callers must not invoke this for TypeSymlink entries.
+func (dc *dirCache) chtimes(root *os.Root, path string, atime, mtime time.Time) error {
+	d, err := dc.openDir(root, filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	utimes := [2]unix.Timespec{timeToTimespec(atime), timeToTimespec(mtime)}
+	if err := unix.UtimesNanoAt(int(d.Fd()), filepath.Base(path), utimes[0:], 0); err != nil {
+		return &os.PathError{Op: "utimensat", Path: path, Err: err}
+	}
+	return nil
+}
+
+// lchtimes sets access and modification times of a symlink at path without
+// following the symlink.
+func (dc *dirCache) lchtimes(root *os.Root, path string, atime, mtime time.Time) error {
+	d, err := dc.openDir(root, filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	utimes := [2]unix.Timespec{timeToTimespec(atime), timeToTimespec(mtime)}
+	if err := unix.UtimesNanoAt(int(d.Fd()), filepath.Base(path), utimes[0:], unix.AT_SYMLINK_NOFOLLOW); err != nil && err != unix.ENOSYS {
+		return &os.PathError{Op: "utimensat", Path: path, Err: err}
+	}
+	return nil
+}

--- a/dircache_unix.go
+++ b/dircache_unix.go
@@ -149,18 +149,3 @@ func (dc *dirCache) chtimes(path string, atime, mtime time.Time) error {
 	}
 	return nil
 }
-
-// lchtimes sets access and modification times of a symlink at path without
-// following the symlink.
-func (dc *dirCache) lchtimes(path string, atime, mtime time.Time) error {
-	d, err := dc.openDir(filepath.Dir(path))
-	if err != nil {
-		return err
-	}
-	utimes := [2]unix.Timespec{timeToTimespec(atime), timeToTimespec(mtime)}
-	// #nosec G115 -- ignore integer overflow conversion for parent.Fd
-	if err := unix.UtimesNanoAt(int(d.Fd()), filepath.Base(path), utimes[0:], unix.AT_SYMLINK_NOFOLLOW); err != nil && err != unix.ENOSYS {
-		return &os.PathError{Op: "utimensat", Path: path, Err: err}
-	}
-	return nil
-}

--- a/dircache_unix.go
+++ b/dircache_unix.go
@@ -11,6 +11,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func newDirCache(root *os.Root) *dirCache {
+	return &dirCache{root: root}
+}
+
 // dirCache caches an open *os.File for the most recently accessed parent
 // directory, eliminating repeated doInRoot path walks for consecutive tar
 // entries in the same directory. doInRoot opens every path component on
@@ -38,8 +42,8 @@ func (dc *dirCache) close() {
 
 // openDir returns an open *os.File for dir within root, reusing the cached
 // fd when possible and re-opening via root.OpenFile otherwise.
-func (dc *dirCache) openDir(root *os.Root, dir string) (*os.File, error) {
-	if dc.file != nil && dc.root == root && dc.path == dir {
+func (dc *dirCache) openDir(dir string) (*os.File, error) {
+	if dc.file != nil && dc.path == dir {
 		return dc.file, nil
 	}
 	if dc.file != nil {
@@ -48,20 +52,19 @@ func (dc *dirCache) openDir(root *os.Root, dir string) (*os.File, error) {
 	}
 	// Open through root so that path resolution is bounded within the
 	// root's security boundary before we cache the raw fd.
-	f, err := root.OpenFile(dir, os.O_RDONLY, 0)
+	f, err := dc.root.OpenFile(dir, os.O_RDONLY, 0)
 	if err != nil {
 		return nil, err
 	}
 	dc.file = f
 	dc.path = dir
-	dc.root = root
 	return f, nil
 }
 
 // openFile creates or truncates the file at path within root, using
 // openat(2) on the cached parent directory fd.
-func (dc *dirCache) openFile(root *os.Root, path string, flag int, perm os.FileMode) (*os.File, error) {
-	d, err := dc.openDir(root, filepath.Dir(path))
+func (dc *dirCache) openFile(path string, flag int, perm os.FileMode) (*os.File, error) {
+	d, err := dc.openDir(filepath.Dir(path))
 	if err != nil {
 		return nil, err
 	}
@@ -77,8 +80,8 @@ func (dc *dirCache) openFile(root *os.Root, path string, flag int, perm os.FileM
 // isExistingDir reports whether path within root exists and is a directory.
 // A false return with a nil error means the path does not exist or is not a
 // directory; the caller should attempt to create it.
-func (dc *dirCache) isExistingDir(root *os.Root, path string) (bool, error) {
-	d, err := dc.openDir(root, filepath.Dir(path))
+func (dc *dirCache) isExistingDir(path string) (bool, error) {
+	d, err := dc.openDir(filepath.Dir(path))
 	if err != nil {
 		return false, err
 	}
@@ -93,8 +96,8 @@ func (dc *dirCache) isExistingDir(root *os.Root, path string) (bool, error) {
 }
 
 // mkdir creates a directory at path within root.
-func (dc *dirCache) mkdir(root *os.Root, path string, perm os.FileMode) error {
-	d, err := dc.openDir(root, filepath.Dir(path))
+func (dc *dirCache) mkdir(path string, perm os.FileMode) error {
+	d, err := dc.openDir(filepath.Dir(path))
 	if err != nil {
 		return err
 	}
@@ -106,8 +109,8 @@ func (dc *dirCache) mkdir(root *os.Root, path string, perm os.FileMode) error {
 }
 
 // lchown sets ownership of path without following symlinks.
-func (dc *dirCache) lchown(root *os.Root, path string, uid, gid int) error {
-	d, err := dc.openDir(root, filepath.Dir(path))
+func (dc *dirCache) lchown(path string, uid, gid int) error {
+	d, err := dc.openDir(filepath.Dir(path))
 	if err != nil {
 		return err
 	}
@@ -120,8 +123,8 @@ func (dc *dirCache) lchown(root *os.Root, path string, uid, gid int) error {
 
 // chmod sets the permission bits of path. It follows symlinks (i.e. acts on
 // the target); callers must not invoke this for TypeSymlink entries.
-func (dc *dirCache) chmod(root *os.Root, path string, mode os.FileMode) error {
-	d, err := dc.openDir(root, filepath.Dir(path))
+func (dc *dirCache) chmod(path string, mode os.FileMode) error {
+	d, err := dc.openDir(filepath.Dir(path))
 	if err != nil {
 		return err
 	}
@@ -134,8 +137,8 @@ func (dc *dirCache) chmod(root *os.Root, path string, mode os.FileMode) error {
 
 // chtimes sets access and modification times of path, following symlinks.
 // Callers must not invoke this for TypeSymlink entries.
-func (dc *dirCache) chtimes(root *os.Root, path string, atime, mtime time.Time) error {
-	d, err := dc.openDir(root, filepath.Dir(path))
+func (dc *dirCache) chtimes(path string, atime, mtime time.Time) error {
+	d, err := dc.openDir(filepath.Dir(path))
 	if err != nil {
 		return err
 	}
@@ -149,8 +152,8 @@ func (dc *dirCache) chtimes(root *os.Root, path string, atime, mtime time.Time) 
 
 // lchtimes sets access and modification times of a symlink at path without
 // following the symlink.
-func (dc *dirCache) lchtimes(root *os.Root, path string, atime, mtime time.Time) error {
-	d, err := dc.openDir(root, filepath.Dir(path))
+func (dc *dirCache) lchtimes(path string, atime, mtime time.Time) error {
+	d, err := dc.openDir(filepath.Dir(path))
 	if err != nil {
 		return err
 	}

--- a/dircache_unix.go
+++ b/dircache_unix.go
@@ -66,7 +66,7 @@ func (dc *dirCache) openFile(root *os.Root, path string, flag int, perm os.FileM
 		return nil, err
 	}
 	// #nosec G115 -- ignore integer overflow conversion for parent.Fd
-	fd, err := unix.Openat(int(d.Fd()), filepath.Base(path), flag|syscall.O_CLOEXEC, uint32(perm))
+	fd, err := unix.Openat(int(d.Fd()), filepath.Base(path), flag|syscall.O_CLOEXEC|syscall.O_NOFOLLOW, uint32(perm))
 	if err != nil {
 		return nil, &os.PathError{Op: "openat", Path: path, Err: err}
 	}

--- a/dircache_unix.go
+++ b/dircache_unix.go
@@ -65,10 +65,12 @@ func (dc *dirCache) openFile(root *os.Root, path string, flag int, perm os.FileM
 	if err != nil {
 		return nil, err
 	}
+	// #nosec G115 -- ignore integer overflow conversion for parent.Fd
 	fd, err := unix.Openat(int(d.Fd()), filepath.Base(path), flag|syscall.O_CLOEXEC, uint32(perm))
 	if err != nil {
 		return nil, &os.PathError{Op: "openat", Path: path, Err: err}
 	}
+	// #nosec G115 -- ignore integer overflow conversion for parent.Fd
 	return os.NewFile(uintptr(fd), path), nil
 }
 
@@ -81,6 +83,7 @@ func (dc *dirCache) isExistingDir(root *os.Root, path string) (bool, error) {
 		return false, err
 	}
 	var stat unix.Stat_t
+	// #nosec G115 -- ignore integer overflow conversion for parent.Fd
 	if err := unix.Fstatat(int(d.Fd()), filepath.Base(path), &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
 		// Any stat error is treated as "not an existing directory"; the
 		// subsequent mkdir call will produce a real error if needed.
@@ -95,6 +98,7 @@ func (dc *dirCache) mkdir(root *os.Root, path string, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
+	// #nosec G115 -- ignore integer overflow conversion for parent.Fd
 	if err := unix.Mkdirat(int(d.Fd()), filepath.Base(path), uint32(perm)); err != nil {
 		return &os.PathError{Op: "mkdirat", Path: path, Err: err}
 	}
@@ -107,6 +111,7 @@ func (dc *dirCache) lchown(root *os.Root, path string, uid, gid int) error {
 	if err != nil {
 		return err
 	}
+	// #nosec G115 -- ignore integer overflow conversion for parent.Fd
 	if err := unix.Fchownat(int(d.Fd()), filepath.Base(path), uid, gid, unix.AT_SYMLINK_NOFOLLOW); err != nil {
 		return &os.PathError{Op: "fchownat", Path: path, Err: err}
 	}
@@ -120,6 +125,7 @@ func (dc *dirCache) chmod(root *os.Root, path string, mode os.FileMode) error {
 	if err != nil {
 		return err
 	}
+	// #nosec G115 -- ignore integer overflow conversion for parent.Fd
 	if err := unix.Fchmodat(int(d.Fd()), filepath.Base(path), fileModeToPerm(mode), 0); err != nil {
 		return &os.PathError{Op: "fchmodat", Path: path, Err: err}
 	}
@@ -134,6 +140,7 @@ func (dc *dirCache) chtimes(root *os.Root, path string, atime, mtime time.Time) 
 		return err
 	}
 	utimes := [2]unix.Timespec{timeToTimespec(atime), timeToTimespec(mtime)}
+	// #nosec G115 -- ignore integer overflow conversion for parent.Fd
 	if err := unix.UtimesNanoAt(int(d.Fd()), filepath.Base(path), utimes[0:], 0); err != nil {
 		return &os.PathError{Op: "utimensat", Path: path, Err: err}
 	}
@@ -148,6 +155,7 @@ func (dc *dirCache) lchtimes(root *os.Root, path string, atime, mtime time.Time)
 		return err
 	}
 	utimes := [2]unix.Timespec{timeToTimespec(atime), timeToTimespec(mtime)}
+	// #nosec G115 -- ignore integer overflow conversion for parent.Fd
 	if err := unix.UtimesNanoAt(int(d.Fd()), filepath.Base(path), utimes[0:], unix.AT_SYMLINK_NOFOLLOW); err != nil && err != unix.ENOSYS {
 		return &os.PathError{Op: "utimensat", Path: path, Err: err}
 	}

--- a/dircache_windows.go
+++ b/dircache_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package archive
+
+import (
+	"os"
+	"time"
+)
+
+// dirCache on Windows delegates all operations to os.Root methods. There is
+// no fd caching because the equivalent openat(2)-style optimisation is not
+// available through the current os.Root API on Windows.
+type dirCache struct{}
+
+// close is a no-op on Windows.
+func (dc *dirCache) close() {}
+
+// openFile opens or creates path within root.
+func (dc *dirCache) openFile(root *os.Root, path string, flag int, perm os.FileMode) (*os.File, error) {
+	return root.OpenFile(path, flag, perm)
+}
+
+// isExistingDir reports whether path within root exists and is a directory.
+func (dc *dirCache) isExistingDir(root *os.Root, path string) (bool, error) {
+	fi, err := root.Lstat(path)
+	if err != nil {
+		return false, nil
+	}
+	return fi.IsDir(), nil
+}
+
+// mkdir creates a directory at path within root.
+func (dc *dirCache) mkdir(root *os.Root, path string, perm os.FileMode) error {
+	return root.Mkdir(path, perm)
+}
+
+// lchown sets ownership of path without following symlinks.
+func (dc *dirCache) lchown(root *os.Root, path string, uid, gid int) error {
+	return root.Lchown(path, uid, gid)
+}
+
+// chtimes sets access and modification times of path.
+func (dc *dirCache) chtimes(root *os.Root, path string, atime, mtime time.Time) error {
+	return root.Chtimes(path, atime, mtime)
+}
+
+// lchtimes is a no-op on Windows; symlink timestamps are not supported.
+func (dc *dirCache) lchtimes(root *os.Root, path string, atime, mtime time.Time) error {
+	return nil
+}

--- a/dircache_windows.go
+++ b/dircache_windows.go
@@ -7,22 +7,28 @@ import (
 	"time"
 )
 
+func newDirCache(root *os.Root) *dirCache {
+	return &dirCache{root: root}
+}
+
 // dirCache on Windows delegates all operations to os.Root methods. There is
 // no fd caching because the equivalent openat(2)-style optimisation is not
 // available through the current os.Root API on Windows.
-type dirCache struct{}
+type dirCache struct {
+	root *os.Root
+}
 
 // close is a no-op on Windows.
 func (dc *dirCache) close() {}
 
 // openFile opens or creates path within root.
-func (dc *dirCache) openFile(root *os.Root, path string, flag int, perm os.FileMode) (*os.File, error) {
-	return root.OpenFile(path, flag, perm)
+func (dc *dirCache) openFile(path string, flag int, perm os.FileMode) (*os.File, error) {
+	return dc.root.OpenFile(path, flag, perm)
 }
 
 // isExistingDir reports whether path within root exists and is a directory.
-func (dc *dirCache) isExistingDir(root *os.Root, path string) (bool, error) {
-	fi, err := root.Lstat(path)
+func (dc *dirCache) isExistingDir(path string) (bool, error) {
+	fi, err := dc.root.Lstat(path)
 	if err != nil {
 		return false, nil
 	}
@@ -30,21 +36,21 @@ func (dc *dirCache) isExistingDir(root *os.Root, path string) (bool, error) {
 }
 
 // mkdir creates a directory at path within root.
-func (dc *dirCache) mkdir(root *os.Root, path string, perm os.FileMode) error {
-	return root.Mkdir(path, perm)
+func (dc *dirCache) mkdir(path string, perm os.FileMode) error {
+	return dc.root.Mkdir(path, perm)
 }
 
 // lchown sets ownership of path without following symlinks.
-func (dc *dirCache) lchown(root *os.Root, path string, uid, gid int) error {
-	return root.Lchown(path, uid, gid)
+func (dc *dirCache) lchown(path string, uid, gid int) error {
+	return dc.root.Lchown(path, uid, gid)
 }
 
 // chtimes sets access and modification times of path.
-func (dc *dirCache) chtimes(root *os.Root, path string, atime, mtime time.Time) error {
-	return root.Chtimes(path, atime, mtime)
+func (dc *dirCache) chtimes(path string, atime, mtime time.Time) error {
+	return dc.root.Chtimes(path, atime, mtime)
 }
 
 // lchtimes is a no-op on Windows; symlink timestamps are not supported.
-func (dc *dirCache) lchtimes(root *os.Root, path string, atime, mtime time.Time) error {
+func (dc *dirCache) lchtimes(path string, atime, mtime time.Time) error {
 	return nil
 }

--- a/dircache_windows.go
+++ b/dircache_windows.go
@@ -49,8 +49,3 @@ func (dc *dirCache) lchown(path string, uid, gid int) error {
 func (dc *dirCache) chtimes(path string, atime, mtime time.Time) error {
 	return dc.root.Chtimes(path, atime, mtime)
 }
-
-// lchtimes is a no-op on Windows; symlink timestamps are not supported.
-func (dc *dirCache) lchtimes(path string, atime, mtime time.Time) error {
-	return nil
-}

--- a/time_nonwindows.go
+++ b/time_nonwindows.go
@@ -33,7 +33,7 @@ func timeToTimespec(time time.Time) unix.Timespec {
 	return unix.NsecToTimespec(time.UnixNano())
 }
 
-func lchtimes(root *os.Root, name string, atime, mtime time.Time) error {
+func lchtimes(root *os.Root, name string, atime, mtime time.Time) error { //nolint:unused
 	dir, base := path.Split(filepath.ToSlash(name))
 	if base == "" {
 		return &os.PathError{Op: "lchtimes", Path: name, Err: syscall.EINVAL}

--- a/time_nonwindows.go
+++ b/time_nonwindows.go
@@ -5,10 +5,6 @@ package archive
 import (
 	"errors"
 	"os"
-	"path"
-	"path/filepath"
-	"strings"
-	"syscall"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -33,23 +29,9 @@ func timeToTimespec(time time.Time) unix.Timespec {
 	return unix.NsecToTimespec(time.UnixNano())
 }
 
-func lchtimes(root *os.Root, name string, atime, mtime time.Time) error { //nolint:unused
-	dir, base := path.Split(filepath.ToSlash(name))
-	if base == "" {
-		return &os.PathError{Op: "lchtimes", Path: name, Err: syscall.EINVAL}
-	}
-
-	dir = strings.TrimSuffix(dir, "/")
-	if dir == "" {
-		dir = "."
-	}
-
-	parent, err := root.Open(dir)
-	if err != nil {
-		return err
-	}
-	defer parent.Close()
-
+// lchtimesAt sets the access and modification times of the symbolic link
+// named by base relative to parent using AT_SYMLINK_NOFOLLOW.
+func lchtimesAt(parent *os.File, base string, atime, mtime time.Time) error {
 	utimes := [2]unix.Timespec{
 		timeToTimespec(atime),
 		timeToTimespec(mtime),
@@ -59,7 +41,7 @@ func lchtimes(root *os.Root, name string, atime, mtime time.Time) error { //noli
 		if errors.Is(err, unix.ENOSYS) {
 			return nil
 		}
-		return &os.PathError{Op: "lchtimes", Path: name, Err: err}
+		return err
 	}
 	return nil
 }

--- a/time_windows.go
+++ b/time_windows.go
@@ -27,6 +27,6 @@ func chtimes(name string, atime time.Time, mtime time.Time) error {
 	return windows.SetFileTime(h, &c, nil, nil)
 }
 
-func lchtimes(root *os.Root, name string, atime time.Time, mtime time.Time) error {
+func lchtimes(root *os.Root, name string, atime time.Time, mtime time.Time) error { //nolint:unused
 	return nil
 }

--- a/time_windows.go
+++ b/time_windows.go
@@ -27,6 +27,6 @@ func chtimes(name string, atime time.Time, mtime time.Time) error {
 	return windows.SetFileTime(h, &c, nil, nil)
 }
 
-func lchtimes(root *os.Root, name string, atime time.Time, mtime time.Time) error { //nolint:unused
+func lchtimesAt(parent *os.File, base string, atime, mtime time.Time) error {
 	return nil
 }


### PR DESCRIPTION
- stacked on https://github.com/moby/go-archive/pull/45
- replaces https://github.com/moby/go-archive/pull/26

Each `root.*(path)` call re-walks every path component via `doInRoot`, costing 2D syscalls per call at path depth D. A typical file entry triggers ~5 `root.*` calls, so at depth 4 that is ~40 syscalls in path traversal alone.

This PR adds a `dirCache` that keeps one parent-directory fd open between entries. Consecutive entries in the same directory reuse the cached fd for all `*at(2)` operations, reducing path-traversal cost to ~5 syscalls per entry regardless of depth.
