### PR TITLE
overlayWhiteoutConverter: fixes and cleanups

### DIFF
--- a/archive_linux.go
+++ b/archive_linux.go
@@ -80,19 +80,26 @@ func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, filePath string) 
 	base := filepath.Base(filePath)
 	dir := filepath.Dir(filePath)
 
-	// If a directory is marked as opaque by the AUFS special file, we need to translate that to overlay.
-	if base == WhiteoutOpaqueDir {
+	switch base {
+	case WhiteoutPrefix, WhiteoutPrefix + ".", WhiteoutPrefix + "..":
+		return false, fmt.Errorf("invalid whiteout entry %q", hdr.Name)
+
+	case WhiteoutOpaqueDir:
+		// If a directory is marked as opaque by the AUFS special file, we need to translate that to overlay.
 		if err := unix.Setxattr(dir, c.opaqueXattr, []byte{'y'}, 0); err != nil {
 			return false, fmt.Errorf("setxattr('%s', %s=y): %w", dir, c.opaqueXattr, err)
 		}
 		// Don't write the whiteout file itself.
 		return false, nil
-	}
 
-	// If a file was deleted, and we are using overlay, we need to create a character device.
-	if originalBase, ok := strings.CutPrefix(base, WhiteoutPrefix); ok {
+	default:
+		originalBase, ok := strings.CutPrefix(base, WhiteoutPrefix)
+		if !ok {
+			// Regular file.
+			return true, nil
+		}
+		// If a file was deleted, and we are using overlay, we need to create a character device.
 		originalPath := filepath.Join(dir, originalBase)
-
 		if err := unix.Mknod(originalPath, unix.S_IFCHR, 0); err != nil {
 			return false, fmt.Errorf("failed to mknod('%s', S_IFCHR, 0): %w", originalPath, err)
 		}
@@ -103,6 +110,4 @@ func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, filePath string) 
 		// Don't write the whiteout file itself.
 		return false, nil
 	}
-
-	return true, nil
 }

--- a/archive_linux.go
+++ b/archive_linux.go
@@ -14,14 +14,26 @@ import (
 
 func getWhiteoutConverter(format WhiteoutFormat) tarWhiteoutConverter {
 	if format == OverlayWhiteoutFormat {
-		return overlayWhiteoutConverter{}
+		return newOverlayWhiteoutConverter()
 	}
 	return nil
 }
 
-type overlayWhiteoutConverter struct{}
+type overlayWhiteoutConverter struct {
+	opaqueXattr string
+}
 
-func (overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, filePath string, fi os.FileInfo) (wo *tar.Header, _ error) {
+func newOverlayWhiteoutConverter() overlayWhiteoutConverter {
+	opaqueXattr := "trusted.overlay.opaque"
+	if userns.RunningInUserNS() {
+		opaqueXattr = "user.overlay.opaque"
+	}
+	return overlayWhiteoutConverter{
+		opaqueXattr: opaqueXattr,
+	}
+}
+
+func (c overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, filePath string, fi os.FileInfo) (wo *tar.Header, _ error) {
 	// convert whiteouts to AUFS format
 	if fi.Mode()&os.ModeCharDevice != 0 && hdr.Devmajor == 0 && hdr.Devminor == 0 {
 		// we just rename the file and make it normal
@@ -37,13 +49,8 @@ func (overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, filePath string, f
 		return nil, nil
 	}
 
-	opaqueXattrName := "trusted.overlay.opaque"
-	if userns.RunningInUserNS() {
-		opaqueXattrName = "user.overlay.opaque"
-	}
-
 	// convert opaque dirs to AUFS format by writing an empty file with the prefix
-	opaque, err := lgetxattr(filePath, opaqueXattrName)
+	opaque, err := lgetxattr(filePath, c.opaqueXattr)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +58,7 @@ func (overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, filePath string, f
 		// FIXME(thaJeztah): return a sentinel error instead of nil, nil
 		return nil, nil
 	}
-	delete(hdr.PAXRecords, paxSchilyXattr+opaqueXattrName)
+	delete(hdr.PAXRecords, paxSchilyXattr+c.opaqueXattr)
 
 	// create a header for the whiteout file
 	// it should inherit some properties from the parent, but be a regular file
@@ -75,14 +82,9 @@ func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, filePath string) 
 
 	// if a directory is marked as opaque by the AUFS special file, we need to translate that to overlay
 	if base == WhiteoutOpaqueDir {
-		opaqueXattrName := "trusted.overlay.opaque"
-		if userns.RunningInUserNS() {
-			opaqueXattrName = "user.overlay.opaque"
-		}
-
-		err := unix.Setxattr(dir, opaqueXattrName, []byte{'y'}, 0)
+		err := unix.Setxattr(dir, c.opaqueXattr, []byte{'y'}, 0)
 		if err != nil {
-			return false, fmt.Errorf("setxattr('%s', %s=y): %w", dir, opaqueXattrName, err)
+			return false, fmt.Errorf("setxattr('%s', %s=y): %w", dir, c.opaqueXattr, err)
 		}
 		// don't write the file itself
 		return false, err

--- a/archive_linux.go
+++ b/archive_linux.go
@@ -80,19 +80,17 @@ func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, filePath string) 
 	base := filepath.Base(filePath)
 	dir := filepath.Dir(filePath)
 
-	// if a directory is marked as opaque by the AUFS special file, we need to translate that to overlay
+	// If a directory is marked as opaque by the AUFS special file, we need to translate that to overlay.
 	if base == WhiteoutOpaqueDir {
-		err := unix.Setxattr(dir, c.opaqueXattr, []byte{'y'}, 0)
-		if err != nil {
+		if err := unix.Setxattr(dir, c.opaqueXattr, []byte{'y'}, 0); err != nil {
 			return false, fmt.Errorf("setxattr('%s', %s=y): %w", dir, c.opaqueXattr, err)
 		}
-		// don't write the file itself
-		return false, err
+		// Don't write the whiteout file itself.
+		return false, nil
 	}
 
-	// if a file was deleted and we are using overlay, we need to create a character device
-	if strings.HasPrefix(base, WhiteoutPrefix) {
-		originalBase := base[len(WhiteoutPrefix):]
+	// If a file was deleted, and we are using overlay, we need to create a character device.
+	if originalBase, ok := strings.CutPrefix(base, WhiteoutPrefix); ok {
 		originalPath := filepath.Join(dir, originalBase)
 
 		if err := unix.Mknod(originalPath, unix.S_IFCHR, 0); err != nil {
@@ -102,7 +100,7 @@ func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, filePath string) 
 			return false, err
 		}
 
-		// don't write the file itself
+		// Don't write the whiteout file itself.
 		return false, nil
 	}
 

--- a/archive_linux_test.go
+++ b/archive_linux_test.go
@@ -154,6 +154,39 @@ func TestOverlayTarUntar(t *testing.T) {
 	checkOverlayWhiteout(t, filepath.Join(dst, "d3", "f1"))
 }
 
+// TestOverlayUntarInvalidWhiteoutNames verifies that malformed whiteout names
+// are rejected. In particular, it rejects whiteout targets of "." and "..";
+// traversal in archive paths is handled by Untar's normal path validation.
+func TestOverlayUntarInvalidWhiteoutNames(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: WhiteoutPrefix},
+		{name: WhiteoutPrefix + "."},
+		{name: WhiteoutPrefix + ".."},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var archive bytes.Buffer
+			tw := tar.NewWriter(&archive)
+
+			err := tw.WriteHeader(&tar.Header{
+				Name:     tc.name,
+				Typeflag: tar.TypeReg,
+				Mode:     0o600,
+			})
+			assert.NilError(t, err)
+			assert.NilError(t, tw.Close())
+
+			err = Untar(bytes.NewReader(archive.Bytes()), t.TempDir(), &TarOptions{
+				WhiteoutFormat: OverlayWhiteoutFormat,
+			})
+			assert.ErrorContains(t, err, "invalid whiteout entry")
+		})
+	}
+}
+
 func TestOverlayTarAUFSUntar(t *testing.T) {
 	restore := overrideUmask(0)
 	defer restore()


### PR DESCRIPTION
overlayWhiteoutConverter: fixes and cleanups

### overlayWhiteoutConverter: store xattr name as field

Store xattr to use when constructing the converter based on whether
we're running with user-namespaces enabled.

### overlayWhiteoutConverter.ConvertRead: minor cleanups

- touch-up comments
- explicitly return nil-error
- use strings.CutPrefix instead of manually

### overlayWhiteoutConverter.ConvertRead: reject malformed whiteout names

Rewrite to use a switch, and reject whiteout entries whose basename is
exactly ".wh." without a filepath.

Such entries do not identify a whiteout target and would otherwise result
in attempting a filesystem operation on the parent directory (or an empty
path), failing with a less informative filesystem error.

Also reject malformed entries whose target resolves to "." or "..". Archive
path traversal remains handled by Untar's normal path validation.
