### PR TITLE
overlayWhiteoutConverter.ConvertRead: reject invalid AUFS hardlink metadata

### DIFF
--- a/archive_linux.go
+++ b/archive_linux.go
@@ -77,7 +77,12 @@ func (c overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, filePath string,
 }
 
 func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, filePath string) (bool, error) {
-	base := filepath.Base(filePath)
+	name := path.Clean(hdr.Name)
+	if name == WhiteoutLinkDir || strings.HasPrefix(name, WhiteoutLinkDir+"/") {
+		// AUFS-internal hardlink metadata is not part of the extracted filesystem.
+		return false, fmt.Errorf("invalid whiteout entry %q", hdr.Name)
+	}
+	base := path.Base(name)
 	dir := filepath.Dir(filePath)
 
 	switch base {

--- a/archive_linux_test.go
+++ b/archive_linux_test.go
@@ -188,6 +188,40 @@ func TestOverlayUntarInvalidWhiteoutNames(t *testing.T) {
 	}
 }
 
+// TestOverlayUntarWhiteoutLinkDir verifies that the AUFS hardlink metadata
+// directory is rejected during overlay whiteout conversion. The ".wh..wh.plnk"
+// entry is invalid archive metadata and must cause extraction to fail rather
+// than being interpreted as a whiteout for ".wh.plnk".
+func TestOverlayUntarWhiteoutLinkDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	var archive bytes.Buffer
+	tw := tar.NewWriter(&archive)
+
+	headers := []*tar.Header{
+		{
+			Name:     WhiteoutLinkDir,
+			Typeflag: tar.TypeDir,
+			Mode:     0o700,
+		},
+		{
+			Name:     WhiteoutLinkDir + "/0123456789",
+			Typeflag: tar.TypeReg,
+			Mode:     0o600,
+		},
+	}
+
+	for _, hdr := range headers {
+		assert.NilError(t, tw.WriteHeader(hdr))
+	}
+	assert.NilError(t, tw.Close())
+
+	err := Untar(&archive, tmpDir, &TarOptions{
+		WhiteoutFormat: OverlayWhiteoutFormat,
+	})
+	assert.ErrorContains(t, err, "invalid whiteout entry")
+}
+
 func TestOverlayTarAUFSUntar(t *testing.T) {
 	restore := overrideUmask(0)
 	defer restore()


### PR DESCRIPTION
Handle WhiteoutLinkDir explicitly when converting whiteouts during
unpack.

The .wh..wh.plnk entry is AUFS-internal hardlink metadata and does not
represent removal of a file. Without an explicit case, it falls through
to the generic whiteout handling and is incorrectly converted into a
whiteout for .wh.plnk.

Treat the metadata entry as an invalid archive and return an error
instead of incorrectly creating an overlay whiteout for it.
