### PR TITLE
archive: Add nested directory parent regression test

### DIFF
--- a/archive_test.go
+++ b/archive_test.go
@@ -1139,6 +1139,25 @@ func TestXGlobalNoParent(t *testing.T) {
 	assert.Check(t, is.ErrorIs(err, os.ErrNotExist))
 }
 
+func TestUntarCreatesImpliedParentForDirectory(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := tar.NewWriter(buf)
+	err := w.WriteHeader(&tar.Header{
+		Name:     "parent/child/",
+		Typeflag: tar.TypeDir,
+		Mode:     0o755,
+	})
+	assert.NilError(t, err)
+	assert.NilError(t, w.Close())
+
+	tmpDir := t.TempDir()
+	assert.NilError(t, Untar(buf, tmpDir, nil))
+
+	info, err := os.Stat(filepath.Join(tmpDir, "parent", "child"))
+	assert.NilError(t, err)
+	assert.Assert(t, info.IsDir())
+}
+
 func TestReplaceFileTarWrapper(t *testing.T) {
 	filesInArchive := 20
 	tests := []struct {


### PR DESCRIPTION
- relates to https://github.com/moby/go-archive/pull/45#discussion_r3621706632

Tar archives may contain a nested directory entry without a separate header for its parent. Verify extraction creates that implied parent before creating the directory entry.