### PR TITLE
TarOptions: document IncludeFiles, ExcludePatterns

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -46,7 +46,12 @@ type (
 
 	// TarOptions wraps the tar options.
 	TarOptions struct {
-		IncludeFiles     []string
+		// IncludeFiles lists archive-relative paths to include.
+		// Paths use POSIX ('/') separators.
+		IncludeFiles []string
+
+		// ExcludePatterns lists archive-relative exclude patterns.
+		// Patterns use POSIX ('/') separators, matching patternmatcher semantics.
 		ExcludePatterns  []string
 		Compression      compression.Compression
 		NoLchown         bool


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/8748

Clarify that IncludeFiles and ExcludePatterns are archive-relative patterns using POSIX ('/') separators.

These fields were introduced in [moby@8b4e0fe][1] for .dockerignore-style pattern matching, but their path semantics were never documented.

Document the expected format to avoid ambiguity with platform-native filesystem paths.

[1]: https://github.com/moby/moby/commit/6d801a3caa54ad7ef574bc426aa1ffc412c5af82