### PR TITLE
drop redundant ExcludePatterns initialization

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -972,9 +972,6 @@ func untarHandler(tarArchive io.Reader, dest string, options *TarOptions, decomp
 	if options == nil {
 		options = &TarOptions{}
 	}
-	if options.ExcludePatterns == nil {
-		options.ExcludePatterns = []string{}
-	}
 
 	r := tarArchive
 	if decompress {

--- a/chrootarchive/archive.go
+++ b/chrootarchive/archive.go
@@ -59,9 +59,6 @@ func untarHandler(tarArchive io.Reader, dest string, options *archive.TarOptions
 	if options == nil {
 		options = &archive.TarOptions{}
 	}
-	if options.ExcludePatterns == nil {
-		options.ExcludePatterns = []string{}
-	}
 
 	// If dest is inside a root then directory is created within chroot by extractor.
 	// This case is only currently used by cp.

--- a/chrootarchive/archive_test.go
+++ b/chrootarchive/archive_test.go
@@ -83,7 +83,6 @@ func TestChrootUntarWithHugeExcludesList(t *testing.T) {
 	if err := os.Mkdir(dest, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	options := &archive.TarOptions{}
 	// 65534 entries of 64-byte strings ~= 4MB of environment space which should overflow
 	// on most systems when passed via environment or command line arguments
 	excludes := make([]string, 65534)
@@ -91,8 +90,10 @@ func TestChrootUntarWithHugeExcludesList(t *testing.T) {
 	for i = range 65534 {
 		excludes[i] = strings.Repeat(string(i), 64)
 	}
-	options.ExcludePatterns = excludes
-	if err := Untar(stream, dest, options); err != nil {
+	err = Untar(stream, dest, &archive.TarOptions{
+		ExcludePatterns: excludes,
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 }

--- a/chrootarchive/diff_unix.go
+++ b/chrootarchive/diff_unix.go
@@ -31,9 +31,6 @@ func applyLayerHandler(dest string, layer io.Reader, options *archive.TarOptions
 	if userns.RunningInUserNS() {
 		options.InUserNS = true
 	}
-	if options.ExcludePatterns == nil {
-		options.ExcludePatterns = []string{}
-	}
 	dest = filepath.Clean(dest)
 	return doUnpackLayer(dest, layer, options)
 }

--- a/diff.go
+++ b/diff.go
@@ -28,9 +28,6 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 	if options == nil {
 		options = &TarOptions{}
 	}
-	if options.ExcludePatterns == nil {
-		options.ExcludePatterns = []string{}
-	}
 
 	aufsTempdir := ""
 	aufsHardlinks := make(map[string]*tar.Header)


### PR DESCRIPTION
Remove the explicit initialization of nil ExcludePatterns to an empty slice.

This normalization was introduced in moby/moby commit 62d83404 ("Pass options to chroot archive untar"):

  https://github.com/moby/moby/commit/62d83404b5f4c9ecdc21e8cab2306a933ce0cdbc

The current go-archive unpack paths no longer serialize or otherwise distinguish nil and empty slices, so the initialization is redundant.