### PR TITLE
Unpack, UnpackLayer: treat tar entry names as POSIX paths

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -831,16 +832,19 @@ loop:
 			continue
 		}
 
-		// Normalize name, for safety and for a simple is-root check
-		// This keeps "../" as-is, but normalizes "/../" to "/". Or Windows:
-		// This keeps "..\" as-is, but normalizes "\..\" to "\".
-		hdr.Name = filepath.Clean(hdr.Name)
-
+		// Strip any leading "/" so absolute entries stay root-relative, and
+		// normalize the POSIX tar path. Skip entries referring to the extraction
+		// root and reject paths that escape it.
+		name := path.Clean(strings.TrimLeft(hdr.Name, "/"))
+		if name == "." {
+			continue
+		}
 		for _, exclude := range options.ExcludePatterns {
-			if strings.HasPrefix(hdr.Name, exclude) {
+			if strings.HasPrefix(name, exclude) {
 				continue loop
 			}
 		}
+		hdr.Name = name
 
 		// Ensure that the parent directory exists.
 		err = createImpliedDirectories(dest, hdr, options)
@@ -849,7 +853,7 @@ loop:
 		}
 
 		// #nosec G305 -- The joined path is checked for path traversal.
-		dstPath := filepath.Join(dest, hdr.Name)
+		dstPath := filepath.Join(dest, filepath.FromSlash(hdr.Name))
 		rel, err := filepath.Rel(dest, dstPath)
 		if err != nil {
 			return err
@@ -913,7 +917,7 @@ loop:
 
 	for _, hdr := range dirs {
 		// #nosec G305 -- The header was checked for path traversal before it was appended to the dirs slice.
-		dstPath := filepath.Join(dest, hdr.Name)
+		dstPath := filepath.Join(dest, filepath.FromSlash(hdr.Name))
 		if err := chtimes(dstPath, boundTime(latestTime(hdr.AccessTime, hdr.ModTime)), boundTime(hdr.ModTime)); err != nil {
 			return err
 		}

--- a/diff.go
+++ b/diff.go
@@ -92,6 +92,10 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			// such hardlinks can be resolved.
 			if strings.HasPrefix(hdr.Name, WhiteoutLinkDir) && hdr.Typeflag == tar.TypeReg {
 				basename := path.Base(hdr.Name)
+				localBasename, err := filepath.Localize(basename)
+				if err != nil || filepath.Base(localBasename) != localBasename {
+					return 0, breakoutError(fmt.Errorf("invalid AUFS hardlink name %q", hdr.Name))
+				}
 				aufsHardlinks[basename] = hdr
 				if aufsTempdir == "" {
 					if aufsTempdir, err = os.MkdirTemp(dest, "dockerplnk"); err != nil {
@@ -99,7 +103,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 					}
 					defer os.RemoveAll(aufsTempdir)
 				}
-				if err := createTarFile(filepath.Join(aufsTempdir, basename), dest, hdr, tr, options); err != nil {
+				if err := createTarFile(filepath.Join(aufsTempdir, localBasename), dest, hdr, tr, options); err != nil {
 					return 0, err
 				}
 			}
@@ -175,9 +179,13 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				linkBasename := path.Base(hdr.Linkname)
 				srcHdr = aufsHardlinks[linkBasename]
 				if srcHdr == nil {
-					return 0, errors.New("invalid aufs hardlink")
+					return 0, errors.New("invalid AUFS hardlink")
 				}
-				tmpFile, err := os.Open(filepath.Join(aufsTempdir, linkBasename))
+				localBasename, err := filepath.Localize(linkBasename)
+				if err != nil || filepath.Base(localBasename) != localBasename {
+					return 0, breakoutError(fmt.Errorf("invalid AUFS hardlink name %q", hdr.Linkname))
+				}
+				tmpFile, err := os.Open(filepath.Join(aufsTempdir, localBasename))
 				if err != nil {
 					return 0, err
 				}

--- a/diff.go
+++ b/diff.go
@@ -90,7 +90,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			// Regular files inside /.wh..wh.plnk can be used as hardlink targets
 			// We don't want this directory, but we need the files in them so that
 			// such hardlinks can be resolved.
-			if strings.HasPrefix(hdr.Name, WhiteoutLinkDir) && hdr.Typeflag == tar.TypeReg {
+			if strings.HasPrefix(hdr.Name, WhiteoutLinkDir+"/") && hdr.Typeflag == tar.TypeReg {
 				basename := path.Base(hdr.Name)
 				localBasename, err := filepath.Localize(basename)
 				if err != nil || filepath.Base(localBasename) != localBasename {
@@ -175,7 +175,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 
 			// Hard links into /.wh..wh.plnk don't work, as we don't extract that directory, so
 			// we manually retarget these into the temporary files we extracted them into
-			if hdr.Typeflag == tar.TypeLink && strings.HasPrefix(path.Clean(hdr.Linkname), WhiteoutLinkDir) {
+			if hdr.Typeflag == tar.TypeLink && strings.HasPrefix(path.Clean(hdr.Linkname), WhiteoutLinkDir+"/") {
 				linkBasename := path.Base(hdr.Linkname)
 				srcHdr = aufsHardlinks[linkBasename]
 				if srcHdr == nil {

--- a/diff.go
+++ b/diff.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -48,8 +49,14 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 
 		size += hdr.Size
 
-		// Normalize name, for safety and for a simple is-root check
-		hdr.Name = filepath.Clean(hdr.Name)
+		// Strip any leading "/" so absolute entries stay root-relative, and
+		// normalize the POSIX tar path. Skip entries referring to the extraction
+		// root and reject paths that escape it.
+		name := path.Clean(strings.TrimLeft(hdr.Name, "/"))
+		if name == "." {
+			continue
+		}
+		hdr.Name = name
 
 		// Windows does not support filenames with colons in them. Ignore
 		// these files. This is not a problem though (although it might
@@ -84,7 +91,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			// We don't want this directory, but we need the files in them so that
 			// such hardlinks can be resolved.
 			if strings.HasPrefix(hdr.Name, WhiteoutLinkDir) && hdr.Typeflag == tar.TypeReg {
-				basename := filepath.Base(hdr.Name)
+				basename := path.Base(hdr.Name)
 				aufsHardlinks[basename] = hdr
 				if aufsTempdir == "" {
 					if aufsTempdir, err = os.MkdirTemp(dest, "dockerplnk"); err != nil {
@@ -102,7 +109,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			}
 		}
 		// #nosec G305 -- The joined path is guarded against path traversal.
-		dstPath := filepath.Join(dest, hdr.Name)
+		dstPath := filepath.Join(dest, filepath.FromSlash(hdr.Name))
 		rel, err := filepath.Rel(dest, dstPath)
 		if err != nil {
 			return 0, err
@@ -164,8 +171,8 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 
 			// Hard links into /.wh..wh.plnk don't work, as we don't extract that directory, so
 			// we manually retarget these into the temporary files we extracted them into
-			if hdr.Typeflag == tar.TypeLink && strings.HasPrefix(filepath.Clean(hdr.Linkname), WhiteoutLinkDir) {
-				linkBasename := filepath.Base(hdr.Linkname)
+			if hdr.Typeflag == tar.TypeLink && strings.HasPrefix(path.Clean(hdr.Linkname), WhiteoutLinkDir) {
+				linkBasename := path.Base(hdr.Linkname)
 				srcHdr = aufsHardlinks[linkBasename]
 				if srcHdr == nil {
 					return 0, errors.New("invalid aufs hardlink")
@@ -197,7 +204,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 
 	for _, hdr := range dirs {
 		// #nosec G305 -- The header was checked for path traversal before it was appended to the dirs slice.
-		dstPath := filepath.Join(dest, hdr.Name)
+		dstPath := filepath.Join(dest, filepath.FromSlash(hdr.Name))
 		if err := chtimes(dstPath, hdr.AccessTime, hdr.ModTime); err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
### Unpack: treat tar entry names as POSIX paths

Normalize tar entry names with path.Clean instead of filepath.Clean.

Tar header paths always use POSIX ('/') separators. Preserve their POSIX
form while operating on archive metadata, deferring conversion to native
paths until the filesystem boundary.

This fixes a bug where ExcludePatterns could fail to match valid archive
entries on Windows because filepath.Clean converted tar paths to native
path separators before exclusion matching.


### UnpackLayer: treat tar entry names as POSIX paths

Normalize tar entry names with path.Clean instead of filepath.Clean.

Tar header paths always use POSIX ('/') separators. Preserve their POSIX
form while operating on archive metadata, deferring conversion to native
paths until the filesystem boundary.


### UnpackLayer: localize AUFS hardlink basenames

Use filepath.Localize when converting AUFS hardlink basenames from tar
header paths to native filesystem paths. This validates that the
basename is a single native path component before it is passed to
filepath.Join(), avoiding reinterpretation of Windows path separators.


### UnpackLayer: tighten AUFS whiteout path matching

Only treat hardlinks targeting entries inside /.wh..wh.plnk as AUFS
metadata by requiring a path-component boundary after the directory
name. This avoids matching similarly prefixed paths while preserving
existing handling of AUFS metadata entries and opaque whiteouts.

