### PR TITLE
archive: fix breakout error type assertions

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -95,10 +95,14 @@ func NewDefaultArchiver() *Archiver {
 	return &Archiver{Untar: Untar}
 }
 
-// breakoutError is used to differentiate errors related to breaking out
-// When testing archive breakout in the unit tests, this error is expected
-// in order for the test to pass.
-type breakoutError error
+// breakoutErr marks errors caused by archive breakout attempts.
+// Unit tests use it to distinguish expected breakout failures from other
+// errors.
+type breakoutErr struct{ error }
+
+func breakoutError(err error) error {
+	return &breakoutErr{error: err}
+}
 
 const (
 	AUFSWhiteoutFormat    WhiteoutFormat = 0 // AUFSWhiteoutFormat is the default format for whiteouts

--- a/utils_test.go
+++ b/utils_test.go
@@ -95,7 +95,8 @@ func testBreakout(untarFn string, tmpdir string, headers []*tar.Header) error {
 		return fmt.Errorf("could not find untar function %q in testUntarFns", untarFn)
 	}
 	if err := untar(dest, reader); err != nil {
-		if !errors.As(err, new(breakoutError)) {
+		var boErr *breakoutErr
+		if !errors.As(err, &boErr) {
 			// If untar returns an error unrelated to an archive breakout,
 			// then consider this an unexpected error and abort.
 			return err


### PR DESCRIPTION
- relates to https://github.com/moby/go-archive/pull/45#discussion_r3625520230

breakoutError was an interface alias, causing errors.As() to match any non-nil error instead of only archive breakout errors.

Replace it with a concrete wrapper type while preserving the existing breakoutError(err) helper.