### PR TITLE
chrootarchive: fix "non-root" skips on Windows

### DIFF
--- a/chrootarchive/archive_test.go
+++ b/chrootarchive/archive_test.go
@@ -38,7 +38,7 @@ func CopyWithTar(src, dst string) error {
 }
 
 func TestChrootTarUntar(t *testing.T) {
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	skip.If(t, runtime.GOOS != "windows" && os.Getuid() != 0, "skipping test that requires root")
 	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.Mkdir(src, 0o700); err != nil {
@@ -66,7 +66,7 @@ func TestChrootTarUntar(t *testing.T) {
 // gh#10426: Verify the fix for having a huge excludes list (like on `docker load` with large # of
 // local images)
 func TestChrootUntarWithHugeExcludesList(t *testing.T) {
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	skip.If(t, runtime.GOOS != "windows" && os.Getuid() != 0, "skipping test that requires root")
 	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.Mkdir(src, 0o700); err != nil {
@@ -161,7 +161,7 @@ func compareFiles(src string, dest string) error {
 
 func TestChrootTarUntarWithSymlink(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "FIXME: figure out why this is failing")
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	skip.If(t, runtime.GOOS != "windows" && os.Getuid() != 0, "skipping test that requires root")
 	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.Mkdir(src, 0o700); err != nil {
@@ -181,7 +181,7 @@ func TestChrootTarUntarWithSymlink(t *testing.T) {
 
 func TestChrootCopyWithTar(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "FIXME: figure out why this is failing")
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	skip.If(t, runtime.GOOS != "windows" && os.Getuid() != 0, "skipping test that requires root")
 	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.Mkdir(src, 0o700); err != nil {
@@ -224,7 +224,7 @@ func TestChrootCopyWithTar(t *testing.T) {
 }
 
 func TestChrootCopyFileWithTar(t *testing.T) {
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	skip.If(t, runtime.GOOS != "windows" && os.Getuid() != 0, "skipping test that requires root")
 	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.Mkdir(src, 0o700); err != nil {
@@ -265,7 +265,7 @@ func TestChrootCopyFileWithTar(t *testing.T) {
 
 func TestChrootUntarPath(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "FIXME: figure out why this is failing")
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	skip.If(t, runtime.GOOS != "windows" && os.Getuid() != 0, "skipping test that requires root")
 	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.Mkdir(src, 0o700); err != nil {
@@ -322,7 +322,7 @@ func (s *slowEmptyTarReader) Read(p []byte) (int, error) {
 }
 
 func TestChrootUntarEmptyArchiveFromSlowReader(t *testing.T) {
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	skip.If(t, runtime.GOOS != "windows" && os.Getuid() != 0, "skipping test that requires root")
 	tmpdir := t.TempDir()
 	dest := filepath.Join(tmpdir, "dest")
 	if err := os.Mkdir(dest, 0o700); err != nil {
@@ -335,7 +335,7 @@ func TestChrootUntarEmptyArchiveFromSlowReader(t *testing.T) {
 }
 
 func TestChrootApplyEmptyArchiveFromSlowReader(t *testing.T) {
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	skip.If(t, runtime.GOOS != "windows" && os.Getuid() != 0, "skipping test that requires root")
 	tmpdir := t.TempDir()
 	dest := filepath.Join(tmpdir, "dest")
 	if err := os.Mkdir(dest, 0o700); err != nil {
@@ -348,7 +348,7 @@ func TestChrootApplyEmptyArchiveFromSlowReader(t *testing.T) {
 }
 
 func TestChrootApplyDotDotFile(t *testing.T) {
-	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
+	skip.If(t, runtime.GOOS != "windows" && os.Getuid() != 0, "skipping test that requires root")
 	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.Mkdir(src, 0o700); err != nil {


### PR DESCRIPTION
Windows os.Getuid() always returns "-1", which would skip these tests. Given that these tests are not constrained by plaform (unix/linux), we should not skip them.