### PR TITLE
archive: fix creation time updates on Windows

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -610,13 +610,13 @@ func createTarFile(root *os.Root, dstPath string, hdr *tar.Header, reader io.Rea
 		// Follow the hardlink only when its target is not itself a symlink.
 		fi, err := root.Lstat(filepath.FromSlash(path.Clean(hdr.Linkname)))
 		if err == nil && fi.Mode()&os.ModeSymlink == 0 {
-			if err := root.Chtimes(dstPath, aTime, mTime); err != nil {
+			if err := chtimes(root, dstPath, aTime, mTime); err != nil {
 				return err
 			}
 		}
 	default:
 		// All other file types follow symlinks.
-		if err := root.Chtimes(dstPath, aTime, mTime); err != nil {
+		if err := chtimes(root, dstPath, aTime, mTime); err != nil {
 			return err
 		}
 	}
@@ -996,7 +996,7 @@ loop:
 
 	for _, d := range dirs {
 		aTime := boundTime(latestTime(d.hdr.AccessTime, d.hdr.ModTime))
-		if err := root.Chtimes(d.name, aTime, boundTime(d.hdr.ModTime)); err != nil {
+		if err := chtimes(root, d.name, aTime, boundTime(d.hdr.ModTime)); err != nil {
 			return err
 		}
 	}

--- a/archive_windows_test.go
+++ b/archive_windows_test.go
@@ -5,7 +5,11 @@ package archive
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
 )
 
 func TestCopyFileWithInvalidDest(t *testing.T) {
@@ -66,4 +70,36 @@ func TestChmodTarEntry(t *testing.T) {
 			t.Fatalf("wrong chmod: expected=%#o got=%#o", v.expected, out)
 		}
 	}
+}
+
+// TestChtimesSetsCreationTime verifies that updating file timestamps also
+// sets the Windows creation time from the modification time.
+func TestChtimesSetsCreationTime(t *testing.T) {
+	tmpDir := t.TempDir()
+	file := filepath.Join(tmpDir, "file")
+	assert.NilError(t, os.WriteFile(file, []byte("hello toto"), 0o644))
+
+	root, err := os.OpenRoot(tmpDir)
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+
+	aTime := time.Date(2000, time.January, 2, 3, 4, 5, 0, time.UTC)
+	mTime := time.Date(2001, time.February, 3, 4, 5, 6, 0, time.UTC)
+	assert.NilError(t, root.Chtimes("file", aTime, mTime))
+
+	fi, err := root.Stat("file")
+	assert.NilError(t, err)
+
+	data, ok := fi.Sys().(*syscall.Win32FileAttributeData)
+	assert.Assert(t, ok)
+
+	var (
+		creationTime     = time.Unix(0, data.CreationTime.Nanoseconds()).UTC()
+		accessTime       = time.Unix(0, data.LastAccessTime.Nanoseconds()).UTC()
+		modificationTime = time.Unix(0, data.LastWriteTime.Nanoseconds()).UTC()
+	)
+
+	assert.Equal(t, creationTime, mTime)
+	assert.Equal(t, accessTime, aTime)
+	assert.Equal(t, modificationTime, mTime)
 }

--- a/archive_windows_test.go
+++ b/archive_windows_test.go
@@ -85,7 +85,7 @@ func TestChtimesSetsCreationTime(t *testing.T) {
 
 	aTime := time.Date(2000, time.January, 2, 3, 4, 5, 0, time.UTC)
 	mTime := time.Date(2001, time.February, 3, 4, 5, 6, 0, time.UTC)
-	assert.NilError(t, root.Chtimes("file", aTime, mTime))
+	assert.NilError(t, chtimes(root, "file", aTime, mTime))
 
 	fi, err := root.Stat("file")
 	assert.NilError(t, err)

--- a/changes_test.go
+++ b/changes_test.go
@@ -122,7 +122,7 @@ func provisionSampleDir(t *testing.T, rootPath string, files []FileData) {
 
 		if info.filetype != Symlink {
 			// Set a consistent ctime, atime for all files and dirs
-			err := chtimes(filepath.Join(rootPath, name), now, now)
+			err := chtimes(root, name, now, now)
 			assert.NilError(t, err)
 		}
 	}
@@ -310,7 +310,7 @@ func mutateSampleDir(t *testing.T, rootPath string) {
 	assert.NilError(t, err)
 
 	// Touch file
-	err = chtimes(filepath.Join(rootPath, "file4"), time.Now().Add(time.Second), time.Now().Add(time.Second))
+	err = chtimes(root, "file4", time.Now().Add(time.Second), time.Now().Add(time.Second))
 	assert.NilError(t, err)
 
 	// Replace file with dir
@@ -345,7 +345,7 @@ func mutateSampleDir(t *testing.T, rootPath string) {
 	assert.NilError(t, err)
 
 	// Touch dir
-	err = chtimes(filepath.Join(rootPath, "dir3"), time.Now().Add(time.Second), time.Now().Add(time.Second))
+	err = chtimes(root, "dir3", time.Now().Add(time.Second), time.Now().Add(time.Second))
 	assert.NilError(t, err)
 }
 

--- a/diff.go
+++ b/diff.go
@@ -213,7 +213,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 	}
 
 	for _, d := range dirs {
-		if err := root.Chtimes(d.name, boundTime(latestTime(d.hdr.AccessTime, d.hdr.ModTime)), boundTime(d.hdr.ModTime)); err != nil {
+		if err := chtimes(root, d.name, boundTime(latestTime(d.hdr.AccessTime, d.hdr.ModTime)), boundTime(d.hdr.ModTime)); err != nil {
 			return 0, err
 		}
 	}

--- a/time_nonwindows.go
+++ b/time_nonwindows.go
@@ -15,12 +15,12 @@ import (
 )
 
 // chtimes changes the access and modification time of a file at the given
-// path.
+// path relative to root.
 //
 // Callers must use boundTime to ensure timestamps are within the range
 // supported by os.Chtimes.
-func chtimes(name string, atime time.Time, mtime time.Time) error {
-	return os.Chtimes(name, atime, mtime)
+func chtimes(root *os.Root, name string, atime, mtime time.Time) error {
+	return root.Chtimes(name, atime, mtime)
 }
 
 func lchtimes(root *os.Root, name string, atime, mtime time.Time) error {

--- a/time_windows.go
+++ b/time_windows.go
@@ -2,36 +2,95 @@ package archive
 
 import (
 	"os"
+	"path/filepath"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
 // chtimes changes the access and modification time of a file at the given
-// path.
+// path relative to root.
 //
 // Callers must use boundTime to ensure timestamps are within the range
 // supported by os.Chtimes.
-func chtimes(name string, atime time.Time, mtime time.Time) error {
-	if err := os.Chtimes(name, atime, mtime); err != nil {
+func chtimes(root *os.Root, name string, atime, mtime time.Time) error {
+	parent, err := root.OpenFile(filepath.Dir(name), os.O_RDONLY, 0)
+	if err != nil {
 		return err
 	}
+	defer parent.Close()
 
-	pathp, err := windows.UTF16PtrFromString(name)
-	if err != nil {
-		return err
-	}
-	h, err := windows.CreateFile(pathp,
-		windows.FILE_WRITE_ATTRIBUTES, windows.FILE_SHARE_WRITE, nil,
-		windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
-	if err != nil {
-		return err
-	}
-	defer windows.Close(h)
-	c := windows.NsecToFiletime(mtime.UnixNano())
-	return windows.SetFileTime(h, &c, nil, nil)
+	return chtimesAt(parent, filepath.Base(name), atime, mtime, false)
 }
 
 func lchtimes(root *os.Root, name string, atime time.Time, mtime time.Time) error {
 	return nil
+}
+
+func chtimesAt(parent *os.File, name string, atime, mtime time.Time, noFollow bool) error {
+	h, err := openForWriteAttributesAt(windows.Handle(parent.Fd()), name, noFollow)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = windows.Close(h) }()
+
+	var (
+		creationTime     = windows.NsecToFiletime(mtime.UnixNano())
+		accessTime       = windows.NsecToFiletime(atime.UnixNano())
+		modificationTime = windows.NsecToFiletime(mtime.UnixNano())
+	)
+	return windows.SetFileTime(h, &creationTime, &accessTime, &modificationTime)
+}
+
+// openForWriteAttributesAt opens name relative to parent with permission to
+// modify its file attributes. If noFollow is true, it does not follow reparse
+// points.
+//
+// This implementation is based on Go's internal Windows Openat support:
+//
+//	https://github.com/golang/go/blob/go1.26.0/src/internal/syscall/windows/at_windows.go
+//
+// It is used by os.Root's Windows implementation for root-relative filesystem
+// operations:
+//
+//	https://github.com/golang/go/blob/go1.26.0/src/os/root_windows.go
+//
+// Keep this implementation aligned with the upstream code until an equivalent
+// operation is available from golang.org/x/sys/windows.
+func openForWriteAttributesAt(parent windows.Handle, name string, noFollow bool) (windows.Handle, error) {
+	name16, err := windows.UTF16FromString(name)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+
+	attrs := uint32(windows.OBJ_CASE_INSENSITIVE)
+	if noFollow {
+		attrs |= windows.OBJ_DONT_REPARSE
+	}
+
+	var handle windows.Handle
+	err = windows.NtCreateFile(
+		&handle,
+		windows.SYNCHRONIZE|windows.FILE_WRITE_ATTRIBUTES,
+		&windows.OBJECT_ATTRIBUTES{
+			Length:        uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+			RootDirectory: parent,
+			ObjectName: &windows.NTUnicodeString{
+				Length:        uint16((len(name16) - 1) * 2), // #nosec G115 -- Length is USHORT by definition. A Windows path component cannot exceed uint16 bytes.
+				MaximumLength: uint16(len(name16) * 2),       // #nosec G115 -- MaximumLength is USHORT by definition. A Windows path component cannot exceed uint16 bytes.
+				Buffer:        &name16[0],
+			},
+			Attributes: attrs,
+		},
+		&windows.IO_STATUS_BLOCK{},
+		nil,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		windows.FILE_OPEN,
+		windows.FILE_OPEN_FOR_BACKUP_INTENT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		0, // EA buffer
+		0, // EA length
+	)
+	return handle, err
 }


### PR DESCRIPTION
- follow-up to https://github.com/moby/go-archive/pull/45


### archive: add Windows creation time test

Add a regression test verifying that updating file timestamps also
updates the file creation time on Windows.

The current implementation preserves this behavior, which is relied on
by archive extraction and should remain unchanged during future
refactoring.

Commit df55fdf3cd62b85c6f22c7b1002c3acb3481f78c replaced the use of
our local chtimes implementation for os.Chtimes, which may be less
advanced and not set the creation time.

### archive: fix creation time updates on Windows

Restore updating the creation time when applying timestamps on
Windows. The previous refactoring to os.Root.Chtimes() only updated
the access and modification times, causing a regression.

