### PR TITLE
archive: do not follow reparse points in chtimes

### DIFF
--- a/archive_windows_test.go
+++ b/archive_windows_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/sys/windows"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestCopyFileWithInvalidDest(t *testing.T) {
@@ -102,4 +104,72 @@ func TestChtimesSetsCreationTime(t *testing.T) {
 	assert.Equal(t, creationTime, mTime)
 	assert.Equal(t, accessTime, aTime)
 	assert.Equal(t, modificationTime, mTime)
+}
+
+// TestChtimesFollowsParentSymlink verifies that chtimes continues to work
+// through symlinks in the parent path. Only the final path component is
+// expected not to be a reparse point.
+func TestChtimesFollowsParentSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	assert.NilError(t, os.Mkdir(filepath.Join(tmpDir, "dir"), 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(tmpDir, "dir", "file"), []byte("hello toto"), 0o644))
+	assert.NilError(t, os.Symlink("dir", filepath.Join(tmpDir, "linked-dir")))
+
+	root, err := os.OpenRoot(tmpDir)
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+
+	want := time.Date(2001, time.February, 3, 4, 5, 6, 0, time.UTC)
+	assert.NilError(t, chtimes(root, filepath.Join("linked-dir", "file"), want, want))
+
+	fi, err := root.Stat(filepath.Join("dir", "file"))
+	assert.NilError(t, err)
+
+	data, ok := fi.Sys().(*syscall.Win32FileAttributeData)
+	assert.Assert(t, ok)
+
+	got := time.Unix(0, data.CreationTime.Nanoseconds()).UTC()
+	assert.Equal(t, got, want)
+}
+
+// TestChtimesRejectsSymlink verifies that chtimes does not follow a final
+// symlink. Tar symlink entries are handled separately through lchtimes, so a
+// symlink encountered by chtimes indicates that the destination changed
+// unexpectedly after its parent path was resolved.
+func TestChtimesRejectsSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	target := filepath.Join(tmpDir, "target")
+	assert.NilError(t, os.WriteFile(target, []byte("hello toto"), 0o644))
+
+	link := filepath.Join(tmpDir, "link")
+	assert.NilError(t, os.Symlink("target", link))
+
+	root, err := os.OpenRoot(tmpDir)
+	assert.NilError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+
+	before, err := root.Stat("target")
+	assert.NilError(t, err)
+	beforeData, ok := before.Sys().(*syscall.Win32FileAttributeData)
+	assert.Assert(t, ok)
+
+	want := time.Date(2001, time.February, 3, 4, 5, 6, 0, time.UTC)
+	err = chtimes(root, "link", want, want)
+
+	// While it may not be a breakout (resolved location could be within rootFs),
+	// we encountered a symlink for a path that we expected not to be.
+	assert.Check(t, is.ErrorType(err, &breakoutErr{}))
+	assert.Check(t, is.ErrorIs(err, windows.STATUS_REPARSE_POINT_ENCOUNTERED))
+
+	// Verify that chtimes did not follow the symlink and modify its target.
+	after, err := root.Stat("target")
+	assert.NilError(t, err)
+	afterData, ok := after.Sys().(*syscall.Win32FileAttributeData)
+	assert.Assert(t, ok)
+
+	assert.Equal(t, beforeData.CreationTime.Nanoseconds(), afterData.CreationTime.Nanoseconds())
+	assert.Equal(t, beforeData.LastAccessTime.Nanoseconds(), afterData.LastAccessTime.Nanoseconds())
+	assert.Equal(t, beforeData.LastWriteTime.Nanoseconds(), afterData.LastWriteTime.Nanoseconds())
 }

--- a/time_windows.go
+++ b/time_windows.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"time"
@@ -12,6 +13,10 @@ import (
 // chtimes changes the access and modification time of a file at the given
 // path relative to root.
 //
+// Symlink entries are handled separately through lchtimes. The final path
+// component is expected not to be a reparse point; if one is encountered,
+// chtimes returns an error.
+//
 // Callers must use boundTime to ensure timestamps are within the range
 // supported by os.Chtimes.
 func chtimes(root *os.Root, name string, atime, mtime time.Time) error {
@@ -21,7 +26,12 @@ func chtimes(root *os.Root, name string, atime, mtime time.Time) error {
 	}
 	defer parent.Close()
 
-	return chtimesAt(parent, filepath.Base(name), atime, mtime, false)
+	// Symlink entries are handled by lchtimes. The destination for all
+	// chtimes callers is therefore expected not to be a reparse point.
+	//
+	// Do not follow the final component: if it was concurrently replaced
+	// with a reparse point, fail instead of updating its target.
+	return chtimesAt(parent, filepath.Base(name), atime, mtime, true)
 }
 
 func lchtimes(root *os.Root, name string, atime time.Time, mtime time.Time) error {
@@ -31,6 +41,11 @@ func lchtimes(root *os.Root, name string, atime time.Time, mtime time.Time) erro
 func chtimesAt(parent *os.File, name string, atime, mtime time.Time, noFollow bool) error {
 	h, err := openForWriteAttributesAt(windows.Handle(parent.Fd()), name, noFollow)
 	if err != nil {
+		if noFollow && errors.Is(err, windows.STATUS_REPARSE_POINT_ENCOUNTERED) {
+			// Encountering a reparse point when noFollow is requested is unexpected.
+			// Treat it as a potential breakout to fail extraction safely.
+			return breakoutError(err)
+		}
 		return err
 	}
 	defer func() { _ = windows.Close(h) }()


### PR DESCRIPTION
- follow-up to https://github.com/moby/go-archive/pull/79#discussion_r3666644518

### archive: add test for unexpected reparse points in chtimes

Verify that chtimes does not follow a final reparse point and leaves the
target unchanged. Symlink entries are handled separately through lchtimes,
so encountering a reparse point here indicates that the destination changed
unexpectedly after its parent path was resolved.

### archive: do not follow reparse points in chtimes

Symlink entries are handled separately through lchtimes. Update chtimes to
open the final path component with OBJ_DONT_REPARSE and return an error if
a reparse point is encountered.

This avoids following an unexpected reparse point if the destination is
replaced after its parent path has been safely resolved, preventing
metadata updates from escaping the intended filesystem object.