### PR TITLE
archive: make breakoutErr unwrap its cause

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -123,6 +123,8 @@ func breakoutError(err error) error {
 	return &breakoutErr{error: err}
 }
 
+func (e *breakoutErr) Unwrap() error { return e.error }
+
 const (
 	AUFSWhiteoutFormat    WhiteoutFormat = 0 // AUFSWhiteoutFormat is the default format for whiteouts
 	OverlayWhiteoutFormat WhiteoutFormat = 1 // OverlayWhiteoutFormat formats whiteout according to the overlay standard.

--- a/archive_test.go
+++ b/archive_test.go
@@ -77,6 +77,14 @@ func createTarFromFiles(t *testing.T, tarPath string, files ...string) {
 	assert.NilError(t, f.Close())
 }
 
+func TestBreakoutErrorUnwrap(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	err := breakoutError(sentinel)
+
+	assert.Check(t, is.ErrorType(err, &breakoutErr{}))
+	assert.Check(t, is.ErrorIs(err, sentinel))
+}
+
 func TestIsArchivePathDir(t *testing.T) {
 	tmp := t.TempDir()
 	assert.NilError(t, os.Mkdir(filepath.Join(tmp, "archivedir"), 0o755))


### PR DESCRIPTION
Implement Unwrap on breakoutErr so callers can inspect the underlying filesystem error with errors.Is and errors.As.

Embedding error preserves its Error method, but does not automatically add the wrapped error to the standard error chain.
