### PR TITLE
archive: create implied parents for directory entries

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -1034,71 +1034,68 @@ func unrepresentableOnWindows(hdr *tar.Header) error {
 // destination at the OS level (openat(2) semantics), preventing escape via
 // symlinks in the destination tree.
 func createImpliedDirectories(root *os.Root, hdr *tar.Header, options *TarOptions) error {
-	// For non-directory entries, ensure that the parent directory exists.
-	if hdr.Typeflag != tar.TypeDir {
-		parent := filepath.FromSlash(path.Dir(strings.TrimSuffix(hdr.Name, "/")))
-		// Skip when the parent is the root itself; nothing to create.
-		if parent == "." || parent == "" {
-			return nil
-		}
-		if _, err := root.Lstat(parent); err == nil {
-			return nil
-		} else if !os.IsNotExist(err) {
-			return err
-		}
-		// RootPair() is confined inside this loop as most cases will not require a call, so we can spend some
-		// unneeded function calls in the uncommon case to encapsulate logic -- implied directories are a niche
-		// usage that reduces the portability of an image.
-		uid, gid := options.IDMap.RootPair()
+	parent := filepath.FromSlash(path.Dir(strings.TrimSuffix(hdr.Name, "/")))
+	// Skip when the parent is the root itself; nothing to create.
+	if parent == "." || parent == "" {
+		return nil
+	}
+	if _, err := root.Lstat(parent); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	// RootPair() is confined inside this loop as most cases will not require a call, so we can spend some
+	// unneeded function calls in the uncommon case to encapsulate logic -- implied directories are a niche
+	// usage that reduces the portability of an image.
+	uid, gid := options.IDMap.RootPair()
 
-		// Similar to [user.MkdirAllAndChown]
-		//
-		// [user.MkdirAllAndChown]: https://pkg.go.dev/github.com/moby/sys/user#MkdirAllAndChown
-		var cur string
-		for c := range strings.SplitSeq(parent, string(os.PathSeparator)) {
-			if c == "" {
-				continue
+	// Similar to [user.MkdirAllAndChown]
+	//
+	// [user.MkdirAllAndChown]: https://pkg.go.dev/github.com/moby/sys/user#MkdirAllAndChown
+	var cur string
+	for c := range strings.SplitSeq(parent, string(os.PathSeparator)) {
+		if c == "" {
+			continue
+		}
+		cur = filepath.Join(cur, c)
+		if err := root.Mkdir(cur, ImpliedDirectoryMode); err != nil {
+			if !errors.Is(err, os.ErrExist) {
+				return err
 			}
-			cur = filepath.Join(cur, c)
-			if err := root.Mkdir(cur, ImpliedDirectoryMode); err != nil {
-				if !errors.Is(err, os.ErrExist) {
-					return err
-				}
 
-				fi, err := root.Stat(cur)
-				if err != nil {
-					return err
-				}
-				if fi.IsDir() {
-					continue
-				}
-				return &os.PathError{Op: "mkdir", Path: cur, Err: syscall.ENOTDIR}
-			}
-			if options.NoLchown {
-				continue
-			}
-			// Only the successful Mkdir case is newly-created.
-			dir, err := root.Open(cur)
+			fi, err := root.Stat(cur)
 			if err != nil {
 				return err
 			}
-			if uid != 0 || gid != 0 {
-				if err := dir.Chown(uid, gid); err != nil {
-					_ = dir.Close()
-					return err
-				}
+			if fi.IsDir() {
+				continue
 			}
-			// root.Mkdir applies the mode subject to the process umask, so
-			// re-apply it with Chmod to guarantee ImpliedDirectoryMode
-			// independent of umask, matching the previous MkdirAllAndChown
-			// behavior.
-			if err := dir.Chmod(ImpliedDirectoryMode); err != nil {
+			return &os.PathError{Op: "mkdir", Path: cur, Err: syscall.ENOTDIR}
+		}
+		if options.NoLchown {
+			continue
+		}
+		// Only the successful Mkdir case is newly-created.
+		dir, err := root.Open(cur)
+		if err != nil {
+			return err
+		}
+		if uid != 0 || gid != 0 {
+			if err := dir.Chown(uid, gid); err != nil {
 				_ = dir.Close()
 				return err
 			}
-			if err := dir.Close(); err != nil {
-				return err
-			}
+		}
+		// root.Mkdir applies the mode subject to the process umask, so
+		// re-apply it with Chmod to guarantee ImpliedDirectoryMode
+		// independent of umask, matching the previous MkdirAllAndChown
+		// behavior.
+		if err := dir.Chmod(ImpliedDirectoryMode); err != nil {
+			_ = dir.Close()
+			return err
+		}
+		if err := dir.Close(); err != nil {
+			return err
 		}
 	}
 

--- a/archive_unix_test.go
+++ b/archive_unix_test.go
@@ -90,6 +90,14 @@ func TestImpliedDirectoryPermissions(t *testing.T) {
 		Name:     "explicit/permissions/umask/file",
 		Typeflag: tar.TypeReg,
 		Mode:     0o666,
+	}, {
+		// Deliberately omit the trailing slash to match the normalized path passed
+		// to createImpliedDirectories; Typeflag is the authoritative directory marker.
+		//
+		// Regression test for https://github.com/moby/moby/issues/53257
+		Name:     "implied/dir-without-trailing-slash",
+		Typeflag: tar.TypeDir,
+		Mode:     0o700,
 	}}
 
 	w := tar.NewWriter(buf)


### PR DESCRIPTION
relates to:

- fixes / addresses https://github.com/moby/moby/issues/53257
- introduced in https://github.com/moby/go-archive/pull/44
- related: https://github.com/moby/go-archive/commit/29b0f33bdc0d0c6f8d90b4eaec470a0cffaccb96 / https://github.com/moby/moby/pull/44196
- related: https://github.com/moby/moby/pull/3295


Tar archives are not required to contain headers for every parent directory. A directory entry can therefore itself have implied parents. For example, an archive may contain:

    etc/dnf/
    etc/dnf/dnf.conf

without containing an entry for `etc/`.

Create implied parent directories regardless of the type of the final entry. The existing root-parent check still prevents attempting to create a parent for top-level entries.

This restores the effective behavior from before go-archive v0.2.1.

The original implementation normalized `hdr.Name` with `filepath.Clean`, then used a trailing path separator as an apparent root check.[1] Its comments described this as an "is-root check" and "Not the root directory".

Because `filepath.Clean` removes trailing separators from non-root paths, a directory entry such as `etc/dnf/` became `etc/dnf` before reaching the check. Its implied parent, `etc`, was therefore created. The filesystem root `/` retained its trailing separator and was skipped; `.` and `./` entered the block but resulted in a harmless check of the already existing extraction root.

The code was later moved into the `createImpliedDirectories` helper.[2] That extraction separated the trailing-separator check from the earlier `filepath.Clean` call, obscuring that directory entries had already lost their trailing separator before reaching the check.

Commit e45dc892 then replaced the ineffective trailing-separator check with `hdr.Typeflag != tar.TypeDir`.[3] Although this appeared to correct the directory detection, it changed the effective behavior: implied parents were no longer created when the final entry was itself a directory.

Both files and directories may have parents implied by their paths. Remove the entry-type check and rely on the existing `parent == "." || parent == ""` guard to skip the extraction root.

[1]: https://github.com/moby/moby/commit/a4868e233c7ebce259fc02d3dbfb241c23471a4a
[2]: https://github.com/moby/go-archive/commit/29b0f33bdc0d0c6f8d90b4eaec470a0cffaccb96
[3]: https://github.com/moby/go-archive/commit/e45dc892270a566df477dd295f4c241aaa6bc0a1