### PR TITLE
archive: Tarballer.Go: suppress io.ErrClosedPipe logs on close

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -698,13 +698,13 @@ func (t *Tarballer) Do() {
 
 	defer func() {
 		// Make sure to check the error on Close.
-		if err := ta.TarWriter.Close(); err != nil {
+		if err := ta.TarWriter.Close(); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 			log.G(context.TODO()).Errorf("Can't close tar writer: %s", err)
 		}
-		if err := t.compressWriter.Close(); err != nil {
+		if err := t.compressWriter.Close(); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 			log.G(context.TODO()).Errorf("Can't close compress writer: %s", err)
 		}
-		if err := t.pipeWriter.Close(); err != nil {
+		if err := t.pipeWriter.Close(); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 			log.G(context.TODO()).Errorf("Can't close pipe writer: %s", err)
 		}
 	}()


### PR DESCRIPTION
Before this patch:

    go test -v -run TestCopyCaseI
    === RUN   TestCopyCaseI
        copy_unix_test.go:117: copying from "/tmp/T/TestCopyCaseI2681583485/001/archive-copy-test2002515556/dir1/." to "/tmp/T/TestCopyCaseI2681583485/001/archive-copy-test3740527566/file1" (not follow symbol link)
        copy_unix_test.go:123: copying from "/tmp/T/TestCopyCaseI2681583485/001/archive-copy-test3740527566/dirSymlink" to "/tmp/T/TestCopyCaseI2681583485/001/archive-copy-test3740527566/file1" (follow symbol link)
    ERRO[0000] Can't add file /tmp/T/TestCopyCaseI2681583485/001/archive-copy-test3740527566/dir1 to tar: io: read/write on closed pipe
    ERRO[0000] Can't close tar writer: io: read/write on closed pipe
    ERRO[0000] Can't add file /tmp/T/TestCopyCaseI2681583485/001/archive-copy-test2002515556/dir1/. to tar: io: read/write on closed pipe
    ERRO[0000] Can't close tar writer: io: read/write on closed pipe
    --- PASS: TestCopyCaseI (0.01s)
    PASS
    ok  	github.com/moby/go-archive	0.828s

After this test, the "closed pipe" errors are ignored when closing;

    go test -v -run TestCopyCaseI
    === RUN   TestCopyCaseI
        copy_unix_test.go:117: copying from "/tmp/T/TestCopyCaseI1855397298/001/archive-copy-test1695505150/dir1/." to "/tmp/T/TestCopyCaseI1855397298/001/archive-copy-test1369902297/file1" (not follow symbol link)
        copy_unix_test.go:123: copying from "/tmp/T/TestCopyCaseI1855397298/001/archive-copy-test1369902297/dirSymlink" to "/tmp/T/TestCopyCaseI1855397298/001/archive-copy-test1369902297/file1" (follow symbol link)
    ERRO[0000] Can't add file /tmp/T/TestCopyCaseI1855397298/001/archive-copy-test1695505150/dir1/. to tar: io: read/write on closed pipe
    ERRO[0000] Can't add file /tmp/T/TestCopyCaseI1855397298/001/archive-copy-test1369902297/dir1 to tar: io: read/write on closed pipe
    --- PASS: TestCopyCaseI (0.01s)
    PASS
    ok  	github.com/moby/go-archive	0.413s