### PR TITLE
archive: Resolve hardlinks through absolute symlinks

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -518,6 +518,7 @@ func createTarFile(root *os.Root, dstPath string, hdr *tar.Header, reader io.Rea
 	// but for os.Foo() calls we need the mode converted to os.FileMode,
 	// so use hdrInfo.Mode() (they differ for e.g. setuid bits)
 	hdrInfo := hdr.FileInfo()
+	var hardlinkSource string
 
 	switch hdr.Typeflag {
 	case tar.TypeDir:
@@ -574,7 +575,13 @@ func createTarFile(root *os.Root, dstPath string, hdr *tar.Header, reader io.Rea
 		if linkname == "." || !filepath.IsLocal(linkname) {
 			return breakoutError(fmt.Errorf("invalid hardlink target %q", hdr.Linkname))
 		}
-		if err := root.Link(filepath.FromSlash(linkname), dstPath); err != nil {
+		hardlinkSource = filepath.FromSlash(linkname)
+		var err error
+		hardlinkSource, err = resolveArchivePath(root, hardlinkSource)
+		if err != nil {
+			return err
+		}
+		if err := root.Link(hardlinkSource, dstPath); err != nil {
 			return err
 		}
 
@@ -665,7 +672,7 @@ func createTarFile(root *os.Root, dstPath string, hdr *tar.Header, reader io.Rea
 		}
 	case tar.TypeLink:
 		// Follow the hardlink only when its target is not itself a symlink.
-		fi, err := root.Lstat(filepath.FromSlash(path.Clean(hdr.Linkname)))
+		fi, err := root.Lstat(hardlinkSource)
 		if err == nil && fi.Mode()&os.ModeSymlink == 0 {
 			if err := chtimes(root, dstPath, aTime, mTime); err != nil {
 				return err

--- a/archive.go
+++ b/archive.go
@@ -439,6 +439,63 @@ func (ta *tarAppender) addTarFile(srcPath, archivePath string) error {
 	return nil
 }
 
+// resolveArchivePath resolves intermediate symlinks in name using chroot-like
+// semantics when os.Root cannot traverse them. The final path component is
+// intentionally preserved because archive extraction may create or replace it.
+//
+// This is a compatibility workaround rather than the preferred long-term
+// implementation. It resolves the path separately before the actual operation,
+// so a concurrent filesystem change may cause the operation to affect a
+// different path within root. The subsequent os.Root operation still confines
+// the operation to root and prevents such a change from escaping it.
+//
+// Paths with missing components are supported. Existing symlinks are resolved,
+// and any remaining nonexistent components are retained for later creation.
+//
+// This helper should eventually be replaced by handle-relative resolution and
+// operations with resolve-in-root semantics, avoiding the resolution/use race
+// and repeated path traversal.
+func resolveArchivePath(root *os.Root, name string) (string, error) {
+	parent, base := filepath.Split(name)
+	if parent == "" {
+		return name, nil
+	}
+
+	parent = filepath.Clean(parent)
+
+	// Follow the final parent component: it is an intermediate component of name,
+	// and an absolute symlink there must trigger the resolve-in-root fallback.
+	_, err := root.Stat(parent)
+	switch {
+	case err == nil:
+		return name, nil
+	case !os.IsNotExist(err) && !isPathEscapes(err):
+		return "", err
+	}
+
+	// Stat may report ENOENT either because an ordinary component is missing or
+	// because a symlink points to a missing target. Resolve the parent in both
+	// cases so that dangling symlinks retain chroot-like semantics.
+	resolvedParent, err := fsRootPath(root.Name(), parent)
+	if err != nil {
+		return "", err
+	}
+
+	relParent, err := filepath.Rel(root.Name(), resolvedParent)
+	if err != nil {
+		return "", err
+	}
+	if relParent != "." && !filepath.IsLocal(relParent) {
+		return "", breakoutError(fmt.Errorf(
+			"resolved parent %q escapes root %q",
+			resolvedParent,
+			root.Name(),
+		))
+	}
+
+	return filepath.Join(relParent, base), nil
+}
+
 // createTarFile extracts a single tar entry into the given root. dstPath is the
 // root-relative path of the entry being extracted, in native (host-separator)
 // form so it can be passed directly to os.Root methods and fsRootPath.
@@ -931,7 +988,10 @@ loop:
 		// dstPath is the native (host-separator) form of the entry name,
 		// used at all filesystem boundaries (os.Root methods, fsRootPath).
 		// hdr.Name stays POSIX (forward-slash) for logical string checks.
-		dstPath := filepath.FromSlash(hdr.Name)
+		dstPath, err := resolveArchivePath(root, filepath.FromSlash(hdr.Name))
+		if err != nil {
+			return err
+		}
 
 		// If dstPath exists we almost always just want to remove and replace it.
 		// The only exception is when it is a directory *and* the file from
@@ -969,7 +1029,7 @@ loop:
 		//
 		// This must be done before whiteoutConverter.ConvertRead, which
 		// may set xattrs on the directory or create whiteout files.
-		if err := createImpliedDirectories(root, hdr, options); err != nil {
+		if err := createImpliedDirectories(root, dstPath, options); err != nil {
 			return err
 		}
 
@@ -1024,17 +1084,19 @@ func unrepresentableOnWindows(hdr *tar.Header) error {
 	return nil
 }
 
-// createImpliedDirectories will create all parent directories of the current path with default permissions, if they do
-// not already exist. This is possible as the tar format supports 'implicit' directories, where their existence is
-// defined by the paths of files in the tar, but there are no header entries for the directories themselves, and thus
-// we most both create them and choose metadata like permissions.
+// createImpliedDirectories creates all parent directories of dstPath with
+// default permissions if they do not already exist. This is necessary because
+// the tar format permits implicit directories whose existence is defined only
+// by file paths, without corresponding directory headers from which metadata
+// could be restored.
 //
-// The caller must have normalized hdr.Name (no leading ".." components).
-// All directory creation is performed via root so it is bounded within the
-// destination at the OS level (openat(2) semantics), preventing escape via
-// symlinks in the destination tree.
-func createImpliedDirectories(root *os.Root, hdr *tar.Header, options *TarOptions) error {
-	parent := filepath.FromSlash(path.Dir(strings.TrimSuffix(hdr.Name, "/")))
+// The caller must pass a normalized, root-relative local path. Any archive-path
+// conversion and resolve-in-root handling must already have been applied.
+// Directory creation is performed through root, so it remains confined to the
+// extraction destination even if the destination tree changes concurrently.
+func createImpliedDirectories(root *os.Root, dstPath string, options *TarOptions) error {
+	parent := filepath.Dir(dstPath)
+
 	// Skip when the parent is the root itself; nothing to create.
 	if parent == "." || parent == "" {
 		return nil

--- a/archive_unix_test.go
+++ b/archive_unix_test.go
@@ -428,6 +428,76 @@ func TestTarUntarWithXattr(t *testing.T) {
 	}
 }
 
+// Absolute symlinks are common in container root filesystems and may come from
+// a lower layer. Later layers must resolve files and hardlink sources through
+// those symlinks relative to the extraction root, not the host root.
+func TestHardlinkSourceThroughAbsoluteSymlink(t *testing.T) {
+	const content = "content"
+
+	unpackers := []struct {
+		name   string
+		unpack func(io.Reader, string) error
+	}{
+		{
+			name: "Unpack",
+			unpack: func(r io.Reader, dest string) error {
+				return Unpack(r, dest, &TarOptions{NoLchown: true})
+			},
+		},
+		{
+			name: "UnpackLayer",
+			unpack: func(r io.Reader, dest string) error {
+				_, err := UnpackLayer(dest, r, &TarOptions{NoLchown: true})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range unpackers {
+		t.Run(tc.name, func(t *testing.T) {
+			dest := t.TempDir()
+			assert.NilError(t, os.Mkdir(filepath.Join(dest, "var"), 0o755))
+			assert.NilError(t, os.Symlink("/run", filepath.Join(dest, "var", "run")))
+
+			buf := &bytes.Buffer{}
+			tw := tar.NewWriter(buf)
+			assert.NilError(t, tw.WriteHeader(&tar.Header{
+				Name:     "var/run/source",
+				Typeflag: tar.TypeReg,
+				Mode:     0o644,
+				Size:     int64(len(content)),
+			}))
+			_, err := io.WriteString(tw, content)
+			assert.NilError(t, err)
+			assert.NilError(t, tw.WriteHeader(&tar.Header{
+				Name:     "var/run/link",
+				Typeflag: tar.TypeLink,
+				Linkname: "var/run/source",
+				Mode:     0o644,
+			}))
+			assert.NilError(t, tw.Close())
+
+			assert.NilError(t, tc.unpack(buf, dest))
+
+			source := filepath.Join(dest, "run", "source")
+			link := filepath.Join(dest, "run", "link")
+			actual, err := os.ReadFile(link)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, actual, []byte(content))
+
+			sourceInode, err := getInode(source)
+			assert.NilError(t, err)
+			linkInode, err := getInode(link)
+			assert.NilError(t, err)
+			assert.Equal(t, sourceInode, linkInode)
+
+			linkCount, err := getNlink(source)
+			assert.NilError(t, err)
+			assert.Equal(t, linkCount, uint64(2))
+		})
+	}
+}
+
 func TestCopyInfoDestinationPathSymlink(t *testing.T) {
 	tmpDir, _ := getTestTempDirs(t)
 

--- a/archive_unix_test.go
+++ b/archive_unix_test.go
@@ -510,3 +510,87 @@ func TestHandleTarTypeBlockCharFifoDeviceRange(t *testing.T) {
 		})
 	}
 }
+
+// TestUntarThroughAbsoluteSymlink verifies that archive extraction follows a
+// pre-existing absolute symlink relative to the extraction root, including
+// when the symlink target or directories following it do not yet exist.
+//
+// Regression test for https://github.com/moby/moby/issues/53258
+func TestUntarThroughAbsoluteSymlink(t *testing.T) {
+	unpackers := []struct {
+		name   string
+		unpack func(dest string, r io.Reader) error
+	}{
+		{
+			name: "Untar",
+			unpack: func(dest string, r io.Reader) error {
+				return Untar(r, dest, &TarOptions{NoLchown: true})
+			},
+		},
+		{
+			name: "UnpackLayer",
+			unpack: func(dest string, r io.Reader) error {
+				_, err := UnpackLayer(dest, r, &TarOptions{NoLchown: true})
+				return err
+			},
+		},
+	}
+
+	for _, unpacker := range unpackers {
+		t.Run(unpacker.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				name         string
+				createTarget bool
+			}{
+				{
+					name:         "existing target",
+					createTarget: true,
+				},
+				{
+					name:         "missing target",
+					createTarget: false,
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					const (
+						name    = "var/run/existing/non-existing/file"
+						content = "content"
+					)
+
+					dest := t.TempDir()
+					assert.NilError(t, os.Mkdir(filepath.Join(dest, "var"), 0o755))
+					if tc.createTarget {
+						assert.NilError(t, os.MkdirAll(
+							filepath.Join(dest, "run", "existing"),
+							0o755,
+						))
+					}
+					assert.NilError(t, os.Symlink(
+						"/run",
+						filepath.Join(dest, "var", "run"),
+					))
+
+					buf := &bytes.Buffer{}
+					tw := tar.NewWriter(buf)
+					assert.NilError(t, tw.WriteHeader(&tar.Header{
+						Name:     name,
+						Typeflag: tar.TypeReg,
+						Mode:     0o644,
+						Size:     int64(len(content)),
+					}))
+					_, err := io.WriteString(tw, content)
+					assert.NilError(t, err)
+					assert.NilError(t, tw.Close())
+
+					assert.NilError(t, unpacker.unpack(dest, buf))
+
+					actual, err := os.ReadFile(filepath.Join(
+						dest, "run", "existing", "non-existing", "file",
+					))
+					assert.NilError(t, err)
+					assert.DeepEqual(t, actual, []byte(content))
+				})
+			}
+		})
+	}
+}

--- a/diff.go
+++ b/diff.go
@@ -29,8 +29,9 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 	tr := tar.NewReader(layer)
 
 	var dirs []unpackedDir
-	// unpackedPaths tracks root-relative paths already written in this layer
-	// so that the AUFS opaque-whiteout walk knows which paths to preserve.
+	// unpackedPaths tracks resolved, native-separator, root-relative paths
+	// already written in this layer so that the AUFS opaque-whiteout walk
+	// knows which paths to preserve.
 	unpackedPaths := make(map[string]struct{})
 
 	if options == nil {
@@ -71,12 +72,6 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			continue
 		}
 
-		// Ensure that the parent directory exists.
-		err = createImpliedDirectories(root, hdr, options)
-		if err != nil {
-			return 0, err
-		}
-
 		// Skip AUFS metadata dirs
 		if strings.HasPrefix(hdr.Name, WhiteoutMetaPrefix) {
 			// Regular files inside /.wh..wh.plnk can be used as hardlink targets
@@ -109,10 +104,15 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 		// dstPath is the native (host-separator) form of the entry name,
 		// used at all filesystem boundaries (os.Root methods, fsRootPath).
 		// The tar-header name (hdr.Name) is POSIX, so convert it here.
-		dstPath := filepath.FromSlash(hdr.Name)
-		base := filepath.Base(dstPath)
-
-		if strings.HasPrefix(base, WhiteoutPrefix) {
+		dstPath, err := resolveArchivePath(root, filepath.FromSlash(hdr.Name))
+		if err != nil {
+			return 0, err
+		}
+		// Ensure that the parent directory exists.
+		if err := createImpliedDirectories(root, dstPath, options); err != nil {
+			return 0, err
+		}
+		if base := filepath.Base(dstPath); strings.HasPrefix(base, WhiteoutPrefix) {
 			dir := filepath.Dir(dstPath)
 			if base == WhiteoutOpaqueDir {
 				_, err := root.Lstat(dir)
@@ -144,9 +144,9 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 						return err
 					}
 
-					// unpackedPaths is keyed by root-relative slash paths; convert
-					// filepath.WalkDir's native path before looking it up.
-					if _, exists := unpackedPaths[filepath.ToSlash(rel)]; !exists {
+					// unpackedPaths is keyed by resolved, native-separator,
+					// root-relative paths, matching filepath.WalkDir's paths.
+					if _, exists := unpackedPaths[rel]; !exists {
 						return root.RemoveAll(rel)
 					}
 					return nil
@@ -206,9 +206,9 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			if hdr.Typeflag == tar.TypeDir {
 				dirs = append(dirs, unpackedDir{hdr: hdr, name: dstPath})
 			}
-			// unpackedPaths is keyed by the POSIX (forward-slash) name so it
-			// matches the ToSlash'd lookup in the opaque-whiteout walk above.
-			unpackedPaths[hdr.Name] = struct{}{}
+			// Record the resolved, native-separator, root-relative path so it
+			// matches the paths produced by the opaque-whiteout walk.
+			unpackedPaths[dstPath] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
- needs: https://github.com/moby/go-archive/pull/93

During https://github.com/moby/go-archive/pull/93 review this case was flagged by an AI review.
Adding this as a separate test.