### PR TITLE
archive: resolve absolute hardlink targets within extraction root (fixes #99)

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -509,6 +509,14 @@ func resolveArchivePath(root *os.Root, name string) (string, error) {
 // the native, root-relative filesystem path used for extraction.
 func resolveHardlinkTarget(root *os.Root, linkname string) (string, error) {
 	cleaned := path.Clean(linkname)
+	if strings.HasPrefix(cleaned, "/") {
+		// Some image builders (e.g. kaniko) write hardlink targets as absolute
+		// paths. Resolve those relative to the extraction root, with chroot-like
+		// semantics matching absolute symlink targets. Strip the root from the
+		// original linkname rather than the cleaned one so that ".." components
+		// are not collapsed against "/" but instead rejected below.
+		cleaned = path.Clean(strings.TrimLeft(linkname, "/"))
+	}
 	if cleaned == "." || !filepath.IsLocal(cleaned) {
 		return "", breakoutError(fmt.Errorf("invalid hardlink target %q", linkname))
 	}

--- a/archive_test.go
+++ b/archive_test.go
@@ -965,6 +965,40 @@ func TestUntarInvalidHardlink(t *testing.T) {
 	}
 }
 
+// TestUntarAbsoluteHardlink verifies that a hardlink whose target is an
+// absolute path (as written by some image builders, e.g. kaniko) is resolved
+// relative to the extraction root, while absolute targets with relative
+// escapes remain rejected (see TestUntarInvalidHardlink).
+func TestUntarAbsoluteHardlink(t *testing.T) {
+	dest := t.TempDir()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	assert.NilError(t, tw.WriteHeader(&tar.Header{
+		Name:     "usr/bin/perlbug",
+		Typeflag: tar.TypeReg,
+		Mode:     0o755,
+		Size:     5,
+	}))
+	_, err := tw.Write([]byte("hello"))
+	assert.NilError(t, err)
+	assert.NilError(t, tw.WriteHeader(&tar.Header{
+		Name:     "usr/bin/perlthanks",
+		Typeflag: tar.TypeLink,
+		Linkname: "/usr/bin/perlbug",
+		Mode:     0o755,
+	}))
+	assert.NilError(t, tw.Close())
+
+	assert.NilError(t, Untar(&buf, dest, &TarOptions{NoLchown: true}))
+
+	fi1, err := os.Stat(filepath.Join(dest, "usr", "bin", "perlbug"))
+	assert.NilError(t, err)
+	fi2, err := os.Stat(filepath.Join(dest, "usr", "bin", "perlthanks"))
+	assert.NilError(t, err)
+	assert.Assert(t, os.SameFile(fi1, fi2), "expected hardlinked files to share an inode")
+}
+
 func TestUntarInvalidSymlink(t *testing.T) {
 	for i, headers := range [][]*tar.Header{
 		{ // try reading victim/hello (../)


### PR DESCRIPTION
- fixes https://github.com/moby/go-archive/issues/99
- relates to / introduced in https://github.com/moby/go-archive/pull/93

The CVE-2026-17106 hardening rejects hardlink entries whose target is an absolute path. Some image builders (e.g. kaniko) write hardlink targets as absolute paths, so layers of such images fail to extract with "invalid hardlink target" since v0.3.0 (Docker 29.7.0).

Resolve absolute hardlink targets relative to the extraction root with chroot-like semantics, matching how absolute symlink targets are handled since 4f6cd58 and how pre-v0.3.0 extraction behaved. The root is stripped from the original linkname rather than the cleaned one, so targets like "/../victim" are not collapsed against "/" but keep failing the filepath.IsLocal check, and the resolved target then passes through resolveArchivePath confined to the os.Root extraction root.


```
Fix a regression introduced in v0.3.0 that caused archive extraction to reject
hardlinks with absolute targets, as produced by some image builders. Absolute
hardlink targets are now resolved relative to the extraction root while paths
that escape the root remain rejected.
```

