### PR TITLE
archive: Resolve symlinks one component at a time

### DIFF
--- a/archive_unix_test.go
+++ b/archive_unix_test.go
@@ -645,6 +645,116 @@ func TestUnpackRejectsRelativeEscapeBeforeAbsoluteSymlink(t *testing.T) {
 	}
 }
 
+// An escaping relative symlink must be rejected even when it is reached through
+// another symlink, so that path resolution never depends on symlinks outside
+// the extraction root.
+func TestUnpackRejectsRelativeEscapeThroughIntermediateSymlink(t *testing.T) {
+	buf := &bytes.Buffer{}
+	tw := tar.NewWriter(buf)
+	assert.NilError(t, tw.WriteHeader(&tar.Header{
+		Name:     "a/absolute/file",
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+	}))
+	assert.NilError(t, tw.Close())
+
+	unpackers := []struct {
+		name   string
+		unpack func(dest string, r io.Reader) error
+	}{
+		{
+			name: "Unpack",
+			unpack: func(dest string, r io.Reader) error {
+				return Unpack(r, dest, &TarOptions{NoLchown: true})
+			},
+		},
+		{
+			name: "UnpackLayer",
+			unpack: func(dest string, r io.Reader) error {
+				_, err := UnpackLayer(dest, r, &TarOptions{NoLchown: true})
+				return err
+			},
+		},
+	}
+
+	for _, unpacker := range unpackers {
+		t.Run(unpacker.name, func(t *testing.T) {
+			// Resolving "a/absolute" must observe "x/escape" instead of letting
+			// the host resolve it, which would find "absolute" outside dest and
+			// redirect the entry through it into dest/target.
+			base := t.TempDir()
+			dest := filepath.Join(base, "dest")
+			assert.NilError(t, os.MkdirAll(filepath.Join(dest, "x"), 0o755))
+			assert.NilError(t, os.Mkdir(filepath.Join(dest, "target"), 0o755))
+			assert.NilError(t, os.Symlink("x/escape", filepath.Join(dest, "a")))
+			assert.NilError(t, os.Symlink("../..", filepath.Join(dest, "x", "escape")))
+			assert.NilError(t, os.Symlink("/target", filepath.Join(base, "absolute")))
+
+			err := unpacker.unpack(dest, bytes.NewReader(buf.Bytes()))
+			assert.Check(t, isPathEscapes(err), "expected path-escape error, got: %v", err)
+
+			_, err = os.Lstat(filepath.Join(dest, "target", "file"))
+			assert.Check(t, os.IsNotExist(err), "archive wrote through rejected path: %v", err)
+		})
+	}
+}
+
+// A chain of relative symlinks that stays inside the extraction root must be
+// followed, including when it ends in an absolute symlink.
+func TestUntarThroughNestedRelativeSymlinks(t *testing.T) {
+	const content = "content"
+
+	buf := &bytes.Buffer{}
+	tw := tar.NewWriter(buf)
+	assert.NilError(t, tw.WriteHeader(&tar.Header{
+		Name:     "a/run/file",
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+		Size:     int64(len(content)),
+	}))
+	_, err := io.WriteString(tw, content)
+	assert.NilError(t, err)
+	assert.NilError(t, tw.Close())
+
+	unpackers := []struct {
+		name   string
+		unpack func(dest string, r io.Reader) error
+	}{
+		{
+			name: "Unpack",
+			unpack: func(dest string, r io.Reader) error {
+				return Unpack(r, dest, &TarOptions{NoLchown: true})
+			},
+		},
+		{
+			name: "UnpackLayer",
+			unpack: func(dest string, r io.Reader) error {
+				_, err := UnpackLayer(dest, r, &TarOptions{NoLchown: true})
+				return err
+			},
+		},
+	}
+
+	for _, unpacker := range unpackers {
+		t.Run(unpacker.name, func(t *testing.T) {
+			// dest/a -> x/inner -> ../var, and dest/var/run -> /run, so
+			// "a/run/file" resolves to dest/run/file.
+			dest := t.TempDir()
+			assert.NilError(t, os.Mkdir(filepath.Join(dest, "x"), 0o755))
+			assert.NilError(t, os.Mkdir(filepath.Join(dest, "var"), 0o755))
+			assert.NilError(t, os.Symlink("x/inner", filepath.Join(dest, "a")))
+			assert.NilError(t, os.Symlink("../var", filepath.Join(dest, "x", "inner")))
+			assert.NilError(t, os.Symlink("/run", filepath.Join(dest, "var", "run")))
+
+			assert.NilError(t, unpacker.unpack(dest, bytes.NewReader(buf.Bytes())))
+
+			actual, err := os.ReadFile(filepath.Join(dest, "run", "file"))
+			assert.NilError(t, err)
+			assert.DeepEqual(t, actual, []byte(content))
+		})
+	}
+}
+
 // Absolute symlinks are common in container root filesystems and may come from
 // a lower layer. Later layers must resolve files and hardlink sources through
 // those symlinks relative to the extraction root, not the host root.

--- a/rootpath.go
+++ b/rootpath.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var errTooManyLinks = errors.New("too many links")
@@ -40,103 +41,90 @@ func fsRootPath(root, path string) (string, error) {
 	return result.path, nil
 }
 
+// resolveFSRootPath resolves path inside root with chroot-like semantics:
+// absolute symlink targets are resolved from root, and ".." never leaves root.
+// Components that do not exist are kept unchanged so callers can create them.
+//
+// The path is walked one component at a time, and each component is joined to
+// the already-resolved, symlink-free prefix. This keeps os.Lstat and
+// os.Readlink from following a symlink in an intermediate component, which
+// would hide that symlink from the escape bookkeeping below.
 func resolveFSRootPath(root, path string) (fsRootPathResult, error) {
 	result := fsRootPathResult{path: root}
 	if path == "" {
 		return result, nil
 	}
-	var linksWalked int // to protect against cycles
-	for {
-		i := linksWalked
-		newpath, err := walkLinks(root, path, &linksWalked, &result)
+
+	var (
+		resolved    string // symlink-free path, relative to root
+		linksWalked int    // to protect against cycles
+	)
+
+	// todo holds the components that are not resolved yet, in reverse order.
+	todo := pushPathComponents(nil, path)
+	for len(todo) > 0 {
+		component := todo[len(todo)-1]
+		todo = todo[:len(todo)-1]
+
+		switch component {
+		case ".":
+			continue
+		case "..":
+			// resolved contains no symlink, so its parent is the lexical one.
+			if resolved = filepath.Dir(resolved); resolved == "." {
+				resolved = ""
+			}
+			continue
+		}
+
+		next := filepath.Join(resolved, component)
+		realPath := filepath.Join(root, next)
+		fi, err := os.Lstat(realPath)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return fsRootPathResult{}, err
+			}
+			// The component does not exist yet; treat it as non-symlink.
+			resolved = next
+			continue
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			resolved = next
+			continue
+		}
+
+		if linksWalked++; linksWalked > 255 {
+			return fsRootPathResult{}, errTooManyLinks
+		}
+		target, err := os.Readlink(realPath)
 		if err != nil {
 			return fsRootPathResult{}, err
 		}
-		path = newpath
-		if i == linksWalked {
-			newpath = filepath.Join(string(os.PathSeparator), newpath)
-			if path == newpath {
-				result.path = filepath.Join(root, newpath)
-				return result, nil
+		if filepath.IsAbs(target) {
+			result.followedAbsoluteLink = true
+			resolved = "" // an absolute target is resolved from root
+		} else if !result.followedAbsoluteLink {
+			// Record an escape before a later absolute link can make the original
+			// os.Root error appear eligible for resolve-in-root fallback.
+			if joined := filepath.Join(resolved, target); joined != "." && !filepath.IsLocal(joined) {
+				result.relativeEscapeBeforeAbsolute = true
 			}
-			path = newpath
 		}
+		todo = pushPathComponents(todo, target)
 	}
+
+	result.path = filepath.Join(root, resolved)
+	return result, nil
 }
 
-func walkLink(root, path string, linksWalked *int, result *fsRootPathResult) (newpath string, islink bool, err error) {
-	if *linksWalked > 255 {
-		return "", false, errTooManyLinks
+// pushPathComponents appends the components of path to todo in reverse order,
+// so that the first component is popped from the end of todo first.
+func pushPathComponents(todo []string, path string) []string {
+	components := strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == filepath.Separator
+	})
+	for i := len(components) - 1; i >= 0; i-- {
+		todo = append(todo, components[i])
 	}
-
-	path = filepath.Join(string(os.PathSeparator), path)
-	if path == string(os.PathSeparator) {
-		return path, false, nil
-	}
-	realPath := filepath.Join(root, path)
-
-	fi, err := os.Lstat(realPath)
-	if err != nil {
-		// If path does not yet exist, treat as non-symlink
-		if os.IsNotExist(err) {
-			return path, false, nil
-		}
-		return "", false, err
-	}
-	if fi.Mode()&os.ModeSymlink == 0 {
-		return path, false, nil
-	}
-	newpath, err = os.Readlink(realPath)
-	if err != nil {
-		return "", false, err
-	}
-	if filepath.IsAbs(newpath) {
-		result.followedAbsoluteLink = true
-	} else if !result.followedAbsoluteLink {
-		// Record an escape before a later absolute link can make the original
-		// os.Root error appear eligible for resolve-in-root fallback.
-		relativeDir, err := filepath.Rel(string(os.PathSeparator), filepath.Dir(path))
-		if err != nil {
-			return "", false, err
-		}
-
-		resolved := filepath.Join(relativeDir, newpath)
-		if resolved != "." && !filepath.IsLocal(resolved) {
-			result.relativeEscapeBeforeAbsolute = true
-		}
-	}
-
-	*linksWalked++
-	return newpath, true, nil
-}
-
-func walkLinks(root, path string, linksWalked *int, result *fsRootPathResult) (string, error) {
-	switch dir, file := filepath.Split(path); {
-	case dir == "":
-		newpath, _, err := walkLink(root, file, linksWalked, result)
-		return newpath, err
-	case file == "":
-		if os.IsPathSeparator(dir[len(dir)-1]) {
-			if dir == string(os.PathSeparator) {
-				return dir, nil
-			}
-			return walkLinks(root, dir[:len(dir)-1], linksWalked, result)
-		}
-		newpath, _, err := walkLink(root, dir, linksWalked, result)
-		return newpath, err
-
-	default:
-		newdir, err := walkLinks(root, dir, linksWalked, result)
-		if err != nil {
-			return "", err
-		}
-		newpath, islink, err := walkLink(root, filepath.Join(newdir, file), linksWalked, result)
-		if err != nil {
-			return "", err
-		}
-		if !islink || filepath.IsAbs(newpath) {
-			return newpath, nil
-		}
-		return filepath.Join(newdir, newpath), nil
-	}
+	return todo
 }


### PR DESCRIPTION
Path resolution passed multi-component paths to os.Lstat and os.Readlink, so the kernel followed symlinks in the intermediate components. The walk never read those links, so it did not record a relative escape, and resolution depended on symlinks located outside the extraction destination.

Given:

dest/a -> x/escape dest/x/escape -> ../.. dest/../absolute -> /target

both Unpack and UnpackLayer accepted the entry `a/absolute/file` and wrote `dest/target/file` through the absolute symlink next to dest, because only `a` was read as a link and its target `x/escape` is local.

Now the walk pops one component at a time and joins it to the already-resolved prefix, so every os.Lstat and os.Readlink call observes exactly the link that is about to be followed. That prefix contains no symlink, so ".." can pop it lexically, and it stays at the root. The escaping link is recorded again and the entry above is rejected with os.Root's path-escape error.