### PR TITLE
archive: add test for chmod fallback on nodev mounts (skipped)

### DIFF
--- a/archive_linux_test.go
+++ b/archive_linux_test.go
@@ -222,3 +222,98 @@ func TestOverlayTarAUFSUntar(t *testing.T) {
 	checkFileMode(t, filepath.Join(dst, "d2", "f1"), 0o660)
 	checkFileMode(t, filepath.Join(dst, "d3", WhiteoutPrefix+"f1"), 0o600)
 }
+
+// TestChmodNoSymlinkFallback verifies that the chmod fallback applies modes to
+// non-symlink entries, including device nodes on a nodev mount.
+//
+// Regression test for https://github.com/moby/go-archive/issues/98
+// Regression test for https://github.com/moby/moby/issues/53299
+func TestChmodNoSymlinkFallback(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		nodev  bool
+		create func(string) error
+		broken bool
+
+		needsRoot bool
+	}{
+		{
+			name: "regular-file",
+			create: func(p string) error {
+				return os.WriteFile(p, nil, 0o600)
+			},
+		},
+		{
+			name: "directory",
+			create: func(p string) error {
+				return os.Mkdir(p, 0o700)
+			},
+		},
+		{
+			name: "fifo",
+			create: func(p string) error {
+				return unix.Mkfifo(p, 0o600)
+			},
+		},
+		{
+			name:  "character-device-on-nodev",
+			nodev: true,
+			create: func(p string) error {
+				return mknod(p, unix.S_IFCHR|0o600, unix.Mkdev(1, 3))
+			},
+			needsRoot: true,
+			broken:    true,
+		},
+		{
+			name:  "block-device-on-nodev",
+			nodev: true,
+			create: func(p string) error {
+				return mknod(p, unix.S_IFBLK|0o600, unix.Mkdev(7, 0))
+			},
+			needsRoot: true,
+			broken:    true,
+		},
+		{
+			// see https://github.com/moby/moby/issues/53299
+			name: "ptmx-device",
+			create: func(entryPath string) error {
+				return mknod(entryPath, unix.S_IFCHR|0o666, unix.Mkdev(5, 2))
+			},
+			needsRoot: true,
+			broken:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.broken {
+				t.Skip("FIXME: fallback cannot open device nodes on nodev mounts")
+			}
+			if tc.needsRoot {
+				skip.If(t, os.Getuid() != 0, "requires root")
+				skip.If(t, userns.RunningInUserNS(), "requires initial user namespace")
+			}
+
+			tmpDir := t.TempDir()
+			if tc.nodev {
+				assert.NilError(t, unix.Mount("tmpfs", tmpDir, "tmpfs", unix.MS_NODEV, ""))
+				t.Cleanup(func() {
+					assert.Check(t, unix.Unmount(tmpDir, 0))
+				})
+			}
+
+			entryPath := filepath.Join(tmpDir, tc.name)
+			assert.NilError(t, tc.create(entryPath))
+
+			parent, err := os.Open(tmpDir)
+			assert.NilError(t, err)
+			defer parent.Close()
+
+			// #nosec G115 -- file descriptors fit in int on supported platforms.
+			err = chmodNoSymlinkFallback(int(parent.Fd()), tc.name, tc.name, 0o640)
+			assert.NilError(t, err, "entryPath: %s", entryPath)
+
+			fi, err := os.Lstat(entryPath)
+			assert.NilError(t, err)
+			assert.Equal(t, fi.Mode().Perm(), os.FileMode(0o640))
+		})
+	}
+}

--- a/archive_nolinux_test.go
+++ b/archive_nolinux_test.go
@@ -1,0 +1,58 @@
+//go:build !linux && !windows
+
+package archive
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+	"gotest.tools/v3/assert"
+)
+
+// TestChmodNoSymlinkFallback verifies that the chmod fallback applies modes to
+// non-symlink entries.
+func TestChmodNoSymlinkFallback(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		create func(string) error
+	}{
+		{
+			name: "regular-file",
+			create: func(p string) error {
+				return os.WriteFile(p, nil, 0o600)
+			},
+		},
+		{
+			name: "directory",
+			create: func(p string) error {
+				return os.Mkdir(p, 0o700)
+			},
+		},
+		{
+			name: "fifo",
+			create: func(p string) error {
+				return unix.Mkfifo(p, 0o600)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			entryPath := filepath.Join(tmpDir, tc.name)
+			assert.NilError(t, tc.create(entryPath))
+
+			parent, err := os.Open(tmpDir)
+			assert.NilError(t, err)
+			defer parent.Close()
+
+			// #nosec G115 -- file descriptors fit in int on supported platforms.
+			err = chmodNoSymlinkFallback(int(parent.Fd()), tc.name, tc.name, 0o640)
+			assert.NilError(t, err, "entryPath: %s", entryPath)
+
+			fi, err := os.Lstat(entryPath)
+			assert.NilError(t, err)
+			assert.Equal(t, fi.Mode().Perm(), os.FileMode(0o640))
+		})
+	}
+}

--- a/archive_unix.go
+++ b/archive_unix.go
@@ -126,10 +126,15 @@ func chmodNoSymlink(root *os.Root, name string, mode os.FileMode) error {
 	}
 
 	// Fallback for systems that cannot perform fchmodat with AT_SYMLINK_NOFOLLOW.
-	// Open the entry without following symlinks and apply the mode through the
-	// resulting file descriptor.
-	// #nosec G115 -- ignore integer overflow conversion for parent.Fd
-	fd, err := unix.Openat(int(parent.Fd()), base, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	return chmodNoSymlinkFallback(int(parent.Fd()), base, name, perm) // #nosec G115 -- ignore integer overflow conversion for parent.Fd
+}
+
+// chmodNoSymlinkFallback applies mode without following the final path
+// component on systems without fchmodat2 support.
+//
+// Callers must have already excluded symlink entries.
+func chmodNoSymlinkFallback(parentFD int, base, name string, perm uint32) error {
+	fd, err := unix.Openat(parentFD, base, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
 	if err != nil {
 		return &os.PathError{Op: "openat", Path: name, Err: err}
 	}


### PR DESCRIPTION
- regression test for https://github.com/moby/go-archive/issues/98