### PR TITLE
archive: fix chmod fallback for device nodes on nodev mounts

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/containerd/log"
+	"github.com/moby/go-archive/internal/archiveoptions"
 	"github.com/moby/patternmatcher"
 	"github.com/moby/sys/sequential"
 	"github.com/moby/sys/user"
@@ -81,8 +82,21 @@ type (
 		// were probably in the archive for a reason, so set this option at
 		// your own peril.
 		BestEffortXattrs bool
+
+		// internalOptions contains options for use by packages within this module.
+		internalOptions *archiveoptions.Options
 	}
 )
+
+// WithProcSelfFD returns a copy of opts prepared for extraction in a
+// filesystem context where /proc/self/fd may not be accessible by path.
+//
+// The caller must invoke the returned cleanup function after extraction
+// completes. On platforms that do not use /proc/self/fd for extraction,
+// the returned cleanup function is a no-op.
+func WithProcSelfFD(opts *TarOptions) (*TarOptions, func(), error) {
+	return withProcSelfFD(opts)
+}
 
 // Archiver implements the Archiver interface and allows the reuse of most utility functions of
 // this package with a pluggable Untar function. Also, to facilitate the passing of specific id
@@ -531,6 +545,7 @@ func createTarFile(root *os.Root, dstPath string, hdr *tar.Header, reader io.Rea
 		Lchown                     = true
 		inUserns, bestEffortXattrs bool
 		chownOpts                  *ChownOpts
+		internalOpts               *archiveoptions.Options
 	)
 
 	// TODO(thaJeztah): make opts a required argument.
@@ -539,6 +554,7 @@ func createTarFile(root *os.Root, dstPath string, hdr *tar.Header, reader io.Rea
 		inUserns = opts.InUserNS // TODO(thaJeztah): consider deprecating opts.InUserNS and detect locally.
 		chownOpts = opts.ChownOpts
 		bestEffortXattrs = opts.BestEffortXattrs
+		internalOpts = opts.internalOptions
 	}
 
 	// hdr.Mode is in linux format, which we can use for sycalls,
@@ -680,7 +696,7 @@ func createTarFile(root *os.Root, dstPath string, hdr *tar.Header, reader io.Rea
 
 	// There is no LChmod, so ignore mode for symlink. Also, this
 	// must happen after chown, as that can modify the file mode
-	if err := handleLChmod(root, dstPath, hardlinkTarget, hdr, hdrInfo); err != nil {
+	if err := handleLChmod(root, dstPath, hardlinkTarget, hdr, hdrInfo, internalOpts); err != nil {
 		return err
 	}
 

--- a/archive_linux.go
+++ b/archive_linux.go
@@ -8,9 +8,27 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/moby/go-archive/internal/archiveoptions"
 	"github.com/moby/sys/userns"
 	"golang.org/x/sys/unix"
 )
+
+func withProcSelfFD(opts *TarOptions) (*TarOptions, func(), error) {
+	procSelfFD, err := os.Open("/proc/self/fd")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var prepared TarOptions
+	if opts != nil {
+		prepared = *opts
+	}
+	prepared.internalOptions = &archiveoptions.Options{
+		ProcSelfFD: procSelfFD,
+	}
+
+	return &prepared, func() { _ = procSelfFD.Close() }, nil
+}
 
 func getWhiteoutConverter(format WhiteoutFormat) tarWhiteoutConverter {
 	if format == OverlayWhiteoutFormat {

--- a/archive_linux_chrooted_test.go
+++ b/archive_linux_chrooted_test.go
@@ -27,6 +27,8 @@ import (
 // moving the shared extraction internals into an internal package may provide
 // a cleaner boundary in the future.
 func TestChmodNoSymlinkFallbackInChrootWithoutProc(t *testing.T) {
+	t.Skip("FIXME: needs changes in chrootarchive to pass through /proc/self/fd/, which isn't present inside the chroot")
+
 	skip.If(t, os.Getuid() != 0, "test requires root")
 	skip.If(t, userns.RunningInUserNS(), "test requires the initial user namespace")
 

--- a/archive_linux_chrooted_test.go
+++ b/archive_linux_chrooted_test.go
@@ -27,8 +27,6 @@ import (
 // moving the shared extraction internals into an internal package may provide
 // a cleaner boundary in the future.
 func TestChmodNoSymlinkFallbackInChrootWithoutProc(t *testing.T) {
-	t.Skip("FIXME: needs changes in chrootarchive to pass through /proc/self/fd/, which isn't present inside the chroot")
-
 	skip.If(t, os.Getuid() != 0, "test requires root")
 	skip.If(t, userns.RunningInUserNS(), "test requires the initial user namespace")
 
@@ -38,6 +36,10 @@ func TestChmodNoSymlinkFallbackInChrootWithoutProc(t *testing.T) {
 	assert.NilError(t, os.Mkdir(filepath.Join(root, filepath.Dir(name)), 0o755))
 	assert.NilError(t, os.WriteFile(filepath.Join(root, name), nil, 0o600))
 
+	opts, cleanup, err := WithProcSelfFD(nil)
+	assert.NilError(t, err)
+	defer cleanup()
+
 	setupFn := func() error {
 		if err := mount.MakeRSlave("/"); err != nil {
 			return err
@@ -46,7 +48,7 @@ func TestChmodNoSymlinkFallbackInChrootWithoutProc(t *testing.T) {
 	}
 
 	var testErr error
-	err := unshare.Go(unix.CLONE_FS|unix.CLONE_NEWNS, setupFn, func() {
+	err = unshare.Go(unix.CLONE_FS|unix.CLONE_NEWNS, setupFn, func() {
 		if _, err := os.Stat("/proc/self/fd"); !errors.Is(err, os.ErrNotExist) {
 			testErr = fmt.Errorf("/proc/self/fd: expected not to exist, got %w", err)
 			return
@@ -59,7 +61,7 @@ func TestChmodNoSymlinkFallbackInChrootWithoutProc(t *testing.T) {
 		}
 		defer unix.Close(parentFD)
 
-		if err := chmodNoSymlinkFallback(parentFD, filepath.Base(name), name, 0o644); err != nil {
+		if err := chmodNoSymlinkFallback(parentFD, filepath.Base(name), name, 0o644, opts.internalOptions); err != nil {
 			testErr = err
 			return
 		}

--- a/archive_linux_test.go
+++ b/archive_linux_test.go
@@ -307,7 +307,7 @@ func TestChmodNoSymlinkFallback(t *testing.T) {
 			defer parent.Close()
 
 			// #nosec G115 -- file descriptors fit in int on supported platforms.
-			err = chmodNoSymlinkFallback(int(parent.Fd()), tc.name, tc.name, 0o640)
+			err = chmodNoSymlinkFallback(int(parent.Fd()), tc.name, tc.name, 0o640, nil)
 			assert.NilError(t, err, "entryPath: %s", entryPath)
 
 			fi, err := os.Lstat(entryPath)

--- a/archive_linux_test.go
+++ b/archive_linux_test.go
@@ -233,7 +233,6 @@ func TestChmodNoSymlinkFallback(t *testing.T) {
 		name   string
 		nodev  bool
 		create func(string) error
-		broken bool
 
 		needsRoot bool
 	}{
@@ -248,7 +247,6 @@ func TestChmodNoSymlinkFallback(t *testing.T) {
 			create: func(p string) error {
 				return os.WriteFile(p, nil, 0o200)
 			},
-			broken: true,
 		},
 		{
 			name: "directory",
@@ -269,7 +267,6 @@ func TestChmodNoSymlinkFallback(t *testing.T) {
 				return mknod(p, unix.S_IFCHR|0o600, unix.Mkdev(1, 3))
 			},
 			needsRoot: true,
-			broken:    true,
 		},
 		{
 			name:  "block-device-on-nodev",
@@ -278,7 +275,6 @@ func TestChmodNoSymlinkFallback(t *testing.T) {
 				return mknod(p, unix.S_IFBLK|0o600, unix.Mkdev(7, 0))
 			},
 			needsRoot: true,
-			broken:    true,
 		},
 		{
 			// see https://github.com/moby/moby/issues/53299
@@ -287,13 +283,9 @@ func TestChmodNoSymlinkFallback(t *testing.T) {
 				return mknod(entryPath, unix.S_IFCHR|0o666, unix.Mkdev(5, 2))
 			},
 			needsRoot: true,
-			broken:    true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.broken {
-				t.Skip("FIXME: fallback cannot open device nodes on nodev mounts")
-			}
 			if tc.needsRoot {
 				skip.If(t, os.Getuid() != 0, "requires root")
 				skip.If(t, userns.RunningInUserNS(), "requires initial user namespace")

--- a/archive_nolinux_test.go
+++ b/archive_nolinux_test.go
@@ -60,7 +60,7 @@ func TestChmodNoSymlinkFallback(t *testing.T) {
 			defer parent.Close()
 
 			// #nosec G115 -- file descriptors fit in int on supported platforms.
-			err = chmodNoSymlinkFallback(int(parent.Fd()), tc.name, tc.name, 0o640)
+			err = chmodNoSymlinkFallback(int(parent.Fd()), tc.name, tc.name, 0o640, nil)
 			assert.NilError(t, err, "entryPath: %s", entryPath)
 
 			fi, err := os.Lstat(entryPath)

--- a/archive_other.go
+++ b/archive_other.go
@@ -2,6 +2,14 @@
 
 package archive
 
+func withProcSelfFD(opts *TarOptions) (*TarOptions, func(), error) {
+	var prepared TarOptions
+	if opts != nil {
+		prepared = *opts
+	}
+	return &prepared, func() {}, nil
+}
+
 func getWhiteoutConverter(format WhiteoutFormat) tarWhiteoutConverter {
 	return nil
 }

--- a/archive_unix.go
+++ b/archive_unix.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/moby/go-archive/internal/archiveoptions"
 	"golang.org/x/sys/unix"
 )
 
@@ -87,7 +88,7 @@ func handleTarTypeBlockCharFifo(root *os.Root, hdr *tar.Header, dstPath string) 
 // handleLChmod applies the mode from hdrInfo to dstPath within root, skipping
 // symlinks (there is no lchmod). For hardlinks, the mode is applied only when
 // the link target is itself not a symlink.
-func handleLChmod(root *os.Root, dstPath string, hardlinkTarget string, hdr *tar.Header, hdrInfo os.FileInfo) error {
+func handleLChmod(root *os.Root, dstPath string, hardlinkTarget string, hdr *tar.Header, hdrInfo os.FileInfo, opts *archiveoptions.Options) error {
 	switch hdr.Typeflag {
 	case tar.TypeSymlink:
 		return nil
@@ -99,17 +100,17 @@ func handleLChmod(root *os.Root, dstPath string, hardlinkTarget string, hdr *tar
 		if err != nil || fi.Mode()&os.ModeSymlink != 0 {
 			return nil
 		}
-		return chmodNoSymlink(root, dstPath, hdrInfo.Mode())
+		return chmodNoSymlink(root, dstPath, hdrInfo.Mode(), opts)
 
 	default:
-		return chmodNoSymlink(root, dstPath, hdrInfo.Mode())
+		return chmodNoSymlink(root, dstPath, hdrInfo.Mode(), opts)
 	}
 }
 
 // chmodNoSymlink applies mode to a non-symlink entry.
 //
 // Callers must have already excluded symlink entries.
-func chmodNoSymlink(root *os.Root, name string, mode os.FileMode) error {
+func chmodNoSymlink(root *os.Root, name string, mode os.FileMode, opts *archiveoptions.Options) error {
 	parent, err := root.OpenFile(filepath.Dir(name), os.O_RDONLY, 0)
 	if err != nil {
 		return err
@@ -126,7 +127,7 @@ func chmodNoSymlink(root *os.Root, name string, mode os.FileMode) error {
 	}
 
 	// Fallback for systems that cannot perform fchmodat with AT_SYMLINK_NOFOLLOW.
-	return chmodNoSymlinkFallback(int(parent.Fd()), base, name, perm) // #nosec G115 -- ignore integer overflow conversion for parent.Fd
+	return chmodNoSymlinkFallback(int(parent.Fd()), base, name, perm, opts) // #nosec G115 -- ignore integer overflow conversion for parent.Fd
 }
 
 // fileModeToPerm returns the subset of an os.FileMode that can be applied

--- a/archive_unix.go
+++ b/archive_unix.go
@@ -129,23 +129,6 @@ func chmodNoSymlink(root *os.Root, name string, mode os.FileMode) error {
 	return chmodNoSymlinkFallback(int(parent.Fd()), base, name, perm) // #nosec G115 -- ignore integer overflow conversion for parent.Fd
 }
 
-// chmodNoSymlinkFallback applies mode without following the final path
-// component on systems without fchmodat2 support.
-//
-// Callers must have already excluded symlink entries.
-func chmodNoSymlinkFallback(parentFD int, base, name string, perm uint32) error {
-	fd, err := unix.Openat(parentFD, base, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
-	if err != nil {
-		return &os.PathError{Op: "openat", Path: name, Err: err}
-	}
-	defer unix.Close(fd)
-
-	if err := unix.Fchmod(fd, perm); err != nil {
-		return &os.PathError{Op: "fchmod", Path: name, Err: err}
-	}
-	return nil
-}
-
 // fileModeToPerm returns the subset of an os.FileMode that can be applied
 // by chmod.
 func fileModeToPerm(mode os.FileMode) uint32 {

--- a/archive_windows.go
+++ b/archive_windows.go
@@ -53,7 +53,7 @@ func handleTarTypeBlockCharFifo(root *os.Root, hdr *tar.Header, path string) err
 }
 
 // handleLChmod is a no-op on Windows because chmod is not supported.
-func handleLChmod(root *os.Root, dstPath string, hardlinkTarget string, hdr *tar.Header, hdrInfo os.FileInfo) error {
+func handleLChmod(root *os.Root, dstPath string, hardlinkTarget string, hdr *tar.Header, hdrInfo os.FileInfo, opts any) error {
 	return nil
 }
 

--- a/chmod_linux.go
+++ b/chmod_linux.go
@@ -1,0 +1,31 @@
+package archive
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+// chmodNoSymlinkFallback applies mode without following the final path
+// component on systems without fchmodat2 support.
+//
+// Callers must have already excluded symlink entries.
+func chmodNoSymlinkFallback(parentFD int, base, name string, perm uint32) error {
+	fd, err := unix.Openat(parentFD, base, unix.O_PATH|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return &os.PathError{Op: "openat", Path: name, Err: err}
+	}
+	defer unix.Close(fd)
+
+	procPath := "/proc/self/fd/" + strconv.Itoa(fd)
+	if err := unix.Chmod(procPath, perm); err != nil {
+		return &os.PathError{
+			Op:   "chmod",
+			Path: name,
+			Err:  fmt.Errorf("via %s: %w", procPath, err),
+		}
+	}
+	return nil
+}

--- a/chmod_linux.go
+++ b/chmod_linux.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 
 	"github.com/moby/go-archive/internal/archiveoptions"
@@ -21,7 +22,10 @@ func chmodNoSymlinkFallback(parentFD int, base, name string, perm uint32, opts *
 	defer unix.Close(fd)
 
 	if opts != nil && opts.ProcSelfFD != nil {
-		if err := unix.Fchmodat(int(opts.ProcSelfFD.Fd()), strconv.Itoa(fd), perm, 0); err != nil {
+		err := unix.Fchmodat(int(opts.ProcSelfFD.Fd()), strconv.Itoa(fd), perm, 0)
+		// Keep the os.File alive until fchmodat has finished using its descriptor.
+		runtime.KeepAlive(opts.ProcSelfFD)
+		if err != nil {
 			return &os.PathError{
 				Op:   "fchmodat",
 				Path: name,

--- a/chmod_linux.go
+++ b/chmod_linux.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/moby/go-archive/internal/archiveoptions"
 	"golang.org/x/sys/unix"
 )
 
@@ -12,19 +13,29 @@ import (
 // component on systems without fchmodat2 support.
 //
 // Callers must have already excluded symlink entries.
-func chmodNoSymlinkFallback(parentFD int, base, name string, perm uint32) error {
+func chmodNoSymlinkFallback(parentFD int, base, name string, perm uint32, opts *archiveoptions.Options) error {
 	fd, err := unix.Openat(parentFD, base, unix.O_PATH|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return &os.PathError{Op: "openat", Path: name, Err: err}
 	}
 	defer unix.Close(fd)
 
-	procPath := "/proc/self/fd/" + strconv.Itoa(fd)
-	if err := unix.Chmod(procPath, perm); err != nil {
-		return &os.PathError{
-			Op:   "chmod",
-			Path: name,
-			Err:  fmt.Errorf("via %s: %w", procPath, err),
+	if opts != nil && opts.ProcSelfFD != nil {
+		if err := unix.Fchmodat(int(opts.ProcSelfFD.Fd()), strconv.Itoa(fd), perm, 0); err != nil {
+			return &os.PathError{
+				Op:   "fchmodat",
+				Path: name,
+				Err:  fmt.Errorf("via pre-opened /proc/self/fd/%d: %w", fd, err),
+			}
+		}
+	} else {
+		procPath := "/proc/self/fd/" + strconv.Itoa(fd)
+		if err := unix.Chmod(procPath, perm); err != nil {
+			return &os.PathError{
+				Op:   "chmod",
+				Path: name,
+				Err:  fmt.Errorf("via %s: %w", procPath, err),
+			}
 		}
 	}
 	return nil

--- a/chmod_unix_nolinux.go
+++ b/chmod_unix_nolinux.go
@@ -5,6 +5,7 @@ package archive
 import (
 	"os"
 
+	"github.com/moby/go-archive/internal/archiveoptions"
 	"golang.org/x/sys/unix"
 )
 
@@ -12,7 +13,7 @@ import (
 // component on systems without fchmodat2 support.
 //
 // Callers must have already excluded symlink entries.
-func chmodNoSymlinkFallback(parentFD int, base, name string, perm uint32) error {
+func chmodNoSymlinkFallback(parentFD int, base, name string, perm uint32, _ *archiveoptions.Options) error {
 	fd, err := unix.Openat(parentFD, base, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
 	if err != nil {
 		return &os.PathError{Op: "openat", Path: name, Err: err}

--- a/chmod_unix_nolinux.go
+++ b/chmod_unix_nolinux.go
@@ -1,0 +1,26 @@
+//go:build !linux && !windows
+
+package archive
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// chmodNoSymlinkFallback applies mode without following the final path
+// component on systems without fchmodat2 support.
+//
+// Callers must have already excluded symlink entries.
+func chmodNoSymlinkFallback(parentFD int, base, name string, perm uint32) error {
+	fd, err := unix.Openat(parentFD, base, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return &os.PathError{Op: "openat", Path: name, Err: err}
+	}
+	defer unix.Close(fd)
+
+	if err := unix.Fchmod(fd, perm); err != nil {
+		return &os.PathError{Op: "fchmod", Path: name, Err: err}
+	}
+	return nil
+}

--- a/chrootarchive/archive_linux.go
+++ b/chrootarchive/archive_linux.go
@@ -9,9 +9,15 @@ import (
 	"github.com/moby/go-archive"
 )
 
-func doUnpack(decompressedArchive io.Reader, relDest, root string, options *archive.TarOptions) error {
+func doUnpack(decompressedArchive io.Reader, relDest, root string, opts *archive.TarOptions) error {
+	options, closeOptions, err := archive.WithProcSelfFD(opts)
+	if err != nil {
+		return err
+	}
+	defer closeOptions()
+
 	done := make(chan error)
-	err := goInChroot(root, func() { done <- archive.Unpack(decompressedArchive, relDest, options) })
+	err = goInChroot(root, func() { done <- archive.Unpack(decompressedArchive, relDest, options) })
 	if err != nil {
 		return err
 	}
@@ -30,14 +36,20 @@ func doPack(relSrc, root string, options *archive.TarOptions) (io.ReadCloser, er
 	return tb.Reader(), nil
 }
 
-func doUnpackLayer(root string, layer io.Reader, options *archive.TarOptions) (int64, error) {
+func doUnpackLayer(root string, layer io.Reader, opts *archive.TarOptions) (int64, error) {
+	options, closeOptions, err := archive.WithProcSelfFD(opts)
+	if err != nil {
+		return 0, err
+	}
+	defer closeOptions()
+
 	type result struct {
 		layerSize int64
 		err       error
 	}
 	done := make(chan result)
 
-	err := goInChroot(root, func() {
+	err = goInChroot(root, func() {
 		// We need to be able to set any perms
 		_ = unix.Umask(0)
 

--- a/internal/archiveoptions/options.go
+++ b/internal/archiveoptions/options.go
@@ -1,0 +1,12 @@
+// Package archiveoptions defines internal options shared between archive and
+// chrootarchive.
+package archiveoptions
+
+import "os"
+
+// Options contains extraction resources supplied by internal callers.
+type Options struct {
+	// ProcSelfFD references /proc/self/fd as opened before entering a chroot.
+	// The caller retains ownership of the file.
+	ProcSelfFD *os.File
+}


### PR DESCRIPTION
- fixes https://github.com/moby/go-archive/issues/98
- fixes / addresses https://github.com/moby/moby/issues/53299
- fixes/ addresses https://github.com/moby/moby/issues/53298
- updates https://github.com/moby/go-archive/pull/45
- [x] stacked on https://github.com/moby/go-archive/pull/102


Commit [f43ca4d][1] introduced an O_RDONLY-based chmod fallback for systems where
fchmodat with AT_SYMLINK_NOFOLLOW is unsupported. Opening a device node this
way fails with EACCES when the filesystem is mounted with nodev.

Use O_PATH to reference the entry without opening the underlying device, then
apply the mode through /proc/self/fd. Keep the existing fallback on non-Linux
Unix platforms.

[1]: https://github.com/moby/go-archive/commit/f43ca4dfa3054c1ff02295d5f40a7cc391225ae4


```
Fix a regression introduced in v0.3.0 that caused archive extraction to fail
when applying permissions to device nodes, including nodes on `nodev`
filesystems and `dev/ptmx`. Device nodes are now referenced without opening
the underlying device before applying their mode.
```